### PR TITLE
Attempt to fix GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           ecmwf/eckit
           ecmwf/odc
           ecmwf/eccodes
+          MathisRosenhauer/libaec@master
           ecmwf/metkit
           ecmwf/fdb
         dependency_branch: develop


### PR DESCRIPTION
ecCodes CI uses libaec@master to build so we probably should too.