### PR TITLE
fixes #4 add cmake fortran module directory using ecbuild method

### DIFF
--- a/src/multio/CMakeLists.txt
+++ b/src/multio/CMakeLists.txt
@@ -188,6 +188,13 @@ ecbuild_add_library(
     PUBLIC_LIBS
         metkit eckit eckit_mpi)
 
+
+if(ECBUILD_INSTALL_FORTRAN_MODULES)
+    install( DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR}/ 
+	     DESTINATION ${INSTALL_INCLUDE_DIR} 
+	     COMPONENT modules)
+endif()
+
 add_subdirectory(fdb5)
 add_subdirectory(maestro)
 add_subdirectory(server)


### PR DESCRIPTION
fixes  #4 by adding (with hints from fckit and eccodes)
```
if(ECBUILD_INSTALL_FORTRAN_MODULES)
    install( DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR}/
             DESTINATION ${INSTALL_INCLUDE_DIR}
             COMPONENT modules)
endif()
```
to src/multio/CMakeLists.txt.

I considered following working(tested) options before deciding which CMakeLists.txt to add the above snippet to:
 -  To root dir CMakeLists.txt, but elegance of using modular ecbuild cmake functions is lost and importantly fortran modules from tests are also installed, which is not desirable.
 -  To CMakeLists.txt in both src/multio/api and src/multio/server as they both have Fortran modules, but thought it is redundant as  `CMAKE_Fortran_MODULE_DIRECTORY` is only needed to be set once for project and having at both places is repetition.  