### PR TITLE
Always compile multio-fdb5 as shared library

### DIFF
--- a/src/multio/fdb5/CMakeLists.txt
+++ b/src/multio/fdb5/CMakeLists.txt
@@ -2,6 +2,8 @@ ecbuild_add_library(
 
     TARGET multio-fdb5
 
+    TYPE SHARED # Due to reliance on factory self registration this library cannot be static
+
     SOURCES
         FDB5Sink.cc
         FDB5Sink.h


### PR DESCRIPTION
Due to reliance on factory self registration this library should never be compiled as static. This may happen otherwise when CMake configuration with -DBUILD_SHARED_LIBS=OFF occurs