### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,3 @@ jobs:
           notify_on: |
             failure
             fixed
-            # success


### PR DESCRIPTION
Remove commented `# success` from notify task

Let's test if the comment was the problem... don't know how the multiline YAML is parsed.