### PR TITLE
Update GribEncoder.cc

### DIFF
--- a/src/multio/action/encode/GribEncoder.cc
+++ b/src/multio/action/encode/GribEncoder.cc
@@ -124,7 +124,7 @@ void tryMapStepToTimeAndCheckTime(eckit::LocalConfiguration& in) {
         }
         else if (hasDataDateTime) {
             startDate = util::toDateInts(in.getLong("dataDate"));
-            startTime = util::toTimeInts(in.getLong("dataTime"));
+            startTime = util::toTimeInts(in.getLong("dataTime") * 100);
         }
         else if (hasDateTime) {
             startDate = util::toDateInts(in.getLong("date"));


### PR DESCRIPTION
The code was initially written under the assumption dataTime is having a format of "HHMMSS" in contrast to mars time with "HHMM" format. No errors have been triggered before until now with recent extremesDT tests where dataTime is extracted on the IFS side and set as "startTime" in the metadata.

This change seems not to be executed through any model run yet. Howeve as the underlying data model is different to the initial assumption, this PR should prevent having potential further issues in the future.