### PR TITLE
Multio hammer thread clean ups

### DIFF
--- a/.github/workflows/old-ci.yml
+++ b/.github/workflows/old-ci.yml
@@ -32,10 +32,7 @@ jobs:
         name:
           - linux gnu-10
           - linux gnu-12
-          - linux clang-12
           - linux clang-14
-          # - linux intel
-          # - macos appclang-14
 
         include:
           - name: linux gnu-10
@@ -55,14 +52,6 @@ jobs:
             caching: true
             cmake_options: -DENABLE_OMP_CXX=OFF
 
-          - name: linux clang-12
-            os: ubuntu-20.04
-            compiler: clang-12
-            compiler_cc: clang-12
-            compiler_cxx: clang++-12
-            compiler_fc: gfortran-10
-            caching: true
-
           - name: linux clang-14
             os: ubuntu-22.04
             compiler: clang-14
@@ -70,25 +59,6 @@ jobs:
             compiler_cxx: clang++-14
             compiler_fc: gfortran-12
             caching: true
-
-          # - name : linux intel
-          #   os: ubuntu-20.04
-          #   compiler: intel
-          #   compiler_cc: icx
-          #   compiler_cxx: icpx
-          #   compiler_fc: ifx
-          #   caching: true
-          #   coverage: false
-
-          # - name: macos appclang-14
-          #   # Xcode compiler requires empty environment variables, so we pass null (~) here
-          #   os: macos-12
-          #   compiler: clang-14
-          #   compiler_cc: ~
-          #   compiler_cxx: ~
-          #   compiler_fc: gfortran-12
-          #   caching: true
-          #   cmake_options: -DMPI_SLOTS=4
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/multio/tools/multio-hammer.cc
+++ b/src/multio/tools/multio-hammer.cc
@@ -691,6 +691,18 @@ void MultioHammer::executeThread() {
         clientPeers.emplace_back(std::make_unique<ThreadPeer>(
             std::thread{&MultioHammer::sendData, this, std::cref(serverPeers), transport, client}));
     }
+
+    for (auto& t : clientPeers) {
+        if (ThreadPeer* p = dynamic_cast<ThreadPeer*>(t.get()); p != nullptr) {
+            p->join();
+        }
+    }
+
+    for (auto& t : serverPeers) {
+        if (ThreadPeer* p = dynamic_cast<ThreadPeer*>(t.get()); p != nullptr) {
+            p->join();
+        }
+    }
 }
 
 void MultioHammer::executePlans(const eckit::option::CmdArgs& args) {

--- a/src/multio/tools/multio-hammer.cc
+++ b/src/multio/tools/multio-hammer.cc
@@ -543,7 +543,7 @@ void MultioHammer::startListening(std::shared_ptr<Transport> transport) {
 void MultioHammer::sendData(const PeerList& serverPeers, std::shared_ptr<Transport> transport,
                             const size_t client_list_id) const {
     // TODO Use multio client poperly instead of accessing transport
-    Peer client = transport->localPeer();
+    const Peer& client = transport->localPeer();
 
     // Open all servers and close them when going out of scope
     std::vector<std::unique_ptr<Connection>> connections;

--- a/src/multio/transport/MpiTransport.cc
+++ b/src/multio/transport/MpiTransport.cc
@@ -347,7 +347,7 @@ void MpiTransport::print(std::ostream& os) const {
     os << "MpiTransport(" << local_ << ")";
 }
 
-Peer MpiTransport::localPeer() const {
+const Peer& MpiTransport::localPeer() const {
     return local_;
 }
 

--- a/src/multio/transport/MpiTransport.h
+++ b/src/multio/transport/MpiTransport.h
@@ -62,7 +62,7 @@ private:
 
     void print(std::ostream& os) const override;
 
-    Peer localPeer() const override;
+    const Peer& localPeer() const override;
 
     void listen() override;
 

--- a/src/multio/transport/TcpTransport.cc
+++ b/src/multio/transport/TcpTransport.cc
@@ -187,7 +187,7 @@ void TcpTransport::bufferedSend(const Message&) {
     throw eckit::NotImplemented{Here()};
 }
 
-Peer TcpTransport::localPeer() const {
+const Peer& TcpTransport::localPeer() const {
     return local_;
 }
 

--- a/src/multio/transport/TcpTransport.h
+++ b/src/multio/transport/TcpTransport.h
@@ -62,7 +62,7 @@ private:
 
     void bufferedSend(const Message& msg) override;
 
-    Peer localPeer() const override;
+    const Peer& localPeer() const override;
 
     PeerList createServerPeers() const override;
 

--- a/src/multio/transport/ThreadTransport.cc
+++ b/src/multio/transport/ThreadTransport.cc
@@ -40,7 +40,7 @@ void ThreadTransport::closeConnections() {
 
 Message ThreadTransport::receive() {
 
-    Peer receiver = localPeer();
+    const Peer& receiver = localPeer();
 
     auto& queue = receiveQueue(receiver);
 
@@ -64,8 +64,9 @@ void ThreadTransport::bufferedSend(const Message&) {
     throw eckit::NotImplemented{Here()};
 }
 
-Peer ThreadTransport::localPeer() const {
-    return Peer{"thread", std::hash<std::thread::id>{}(std::this_thread::get_id())};
+const Peer& ThreadTransport::localPeer() const {
+    thread_local static Peer peer{"thread", std::hash<std::thread::id>{}(std::this_thread::get_id())};
+    return peer;
 }
 
 PeerList ThreadTransport::createServerPeers() const {

--- a/src/multio/transport/ThreadTransport.h
+++ b/src/multio/transport/ThreadTransport.h
@@ -55,7 +55,7 @@ private:
 
     void print(std::ostream& os) const override;
 
-    Peer localPeer() const override;
+    const Peer& localPeer() const override;
 
     PeerList createServerPeers() const override;
 

--- a/src/multio/transport/ThreadTransport.h
+++ b/src/multio/transport/ThreadTransport.h
@@ -31,6 +31,8 @@ class ThreadPeer : public Peer {
 public:
     ThreadPeer(std::thread t);
 
+    void join();
+
 private:
     util::ScopedThread thread_;
 };

--- a/src/multio/transport/Transport.h
+++ b/src/multio/transport/Transport.h
@@ -55,7 +55,7 @@ public:  // methods
 
     virtual void bufferedSend(const Message& message) = 0;
 
-    virtual Peer localPeer() const = 0;
+    virtual const Peer& localPeer() const = 0;
 
     virtual void listen();
 

--- a/src/multio/util/ScopedThread.h
+++ b/src/multio/util/ScopedThread.h
@@ -9,18 +9,30 @@ namespace multio::util {
 
 class ScopedThread {
 public:
-    explicit ScopedThread(std::thread thread) : thread_(std::move(thread)) {
+    explicit ScopedThread(std::thread thread) : joined_{false}, thread_(std::move(thread)) {
         if (!thread_.joinable()) {
             throw eckit::SeriousBug("No thread");
         }
     }
 
-    ~ScopedThread() { thread_.join(); }
+    ~ScopedThread() { join(); }
 
     ScopedThread(const ScopedThread& rhs) = delete;
     ScopedThread& operator=(const ScopedThread& rhs) = delete;
 
+    void join() {
+        if (joined_)
+            return;
+
+        joined_ = true;
+
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+    }
+
 private:  // members
+    bool joined_;
     std::thread thread_;
 };
 


### PR DESCRIPTION
The branch was intended to fix the SEGFAULT... however the reason therefor is in eckit. Nevertheless here are same changes:
  * Using returned iterator of `emplace` instead of accessing the same key multiple times
  * Properly/Explicitly join threads... The behaviour of a ScopedThread is a little bit confusing. 
     The clients have get passed an array of Server list peers... After all threads have been spawned up, this thread is about to    be destructed. OFC destruction is delayed due to thread joining from the destructor, however I think it is very bad habit to use an object that is about to be destructed. Technically some other members could have already been destructed, that's why I really prefer to join explicitly