### PR TITLE
avoid checks for empty sets in the select action:

### DIFF
--- a/src/multio/action/select/Select.cc
+++ b/src/multio/action/select/Select.cc
@@ -23,7 +23,7 @@ namespace multio::action {
 
 //--------------------------------------------------------------------------------------------------
 
-Select::Select(const ComponentConfiguration& compConf) : ChainedAction{compConf}, selectors_{compConf.parsedConfig()} {}
+Select::Select(const ComponentConfiguration& compConf) : ChainedAction{compConf}, selectors_{MatchReduce::construct( compConf.parsedConfig())} {}
 
 void Select::executeImpl(Message msg) {
     if (matches(msg)) {

--- a/src/multio/message/MetadataMatcher.cc
+++ b/src/multio/message/MetadataMatcher.cc
@@ -74,12 +74,13 @@ bool MatchKeys::matches(const Metadata& md) const {
             break;
         }
         if (kv.second.find(searchKey->second) == kv.second.end()) {
-            if (enforceSameKeyTypes_) {
-                if (kv.second.size() == 0) {
-                    std::ostringstream oss;
-                    oss << "[enforce-same-key-type] Matcher for key \"" << kv.first << "\" is an empty set";
-                    throw MetadataException(oss.str());
-                }
+            if (enforceSameKeyTypes_ && kv.second.size() > 0 ) {
+                // Note: NEMO needs the possibiity to use empty sets!!!
+                //if (kv.second.size() == 0) {
+                //    std::ostringstream oss;
+                //    oss << "[enforce-same-key-type] Matcher for key \"" << kv.first << "\" is an empty set";
+                //    throw MetadataException(oss.str());
+                //}
 
                 if (kv.second.begin()->index() != searchKey->second.index()) {
                     std::ostringstream oss;


### PR DESCRIPTION
 - Update check conditions in MetadataMatcher
 - Change the construction of the matcher in the Select action