### PR TITLE
Restore new data governance keys for Maestro CDOs

### DIFF
--- a/src/multio/maestro/MaestroSink.cc
+++ b/src/multio/maestro/MaestroSink.cc
@@ -44,19 +44,13 @@ static void setInt64Value(multio::MaestroCdo& cdo, const std::string& key, const
 using MaestroKeySetter = std::add_pointer<void(multio::MaestroCdo&, const std::string&, const std::string&)>::type;
 
 static const std::map<std::string, MaestroKeySetter> cdoValueSetters{
-    {"class", &setStringValue},   {"expver", &setStringValue},  {"stream", &setStringValue},
-    {"date", &setStringValue},    {"time", &setStringValue},    {"domain", &setStringValue},
-    {"type", &setStringValue},    {"levtype", &setStringValue}, {"step", &setInt64Value},
-    {"anoffset", &setInt64Value}, {"levelist", &setInt64Value}, {"param", &setInt64Value},
-    // # Additional attributes (D340.2.2.3). These keys will be put back once version 2.2.3 is released.
-    //{"experiment", &setStringValue},
-    //{"activity", &setStringValue},
-    //{"generation", &setInt64Value},
-    //{"realization", &setInt64Value},
-    //{"model", &setStringValue},
-    //{"resolution", &setStringValue},
-    //{"frequency", &setStringValue},
-    //{"direction", &setStringValue},
+    {"class", &setStringValue},      {"expver", &setStringValue},   {"stream", &setStringValue},
+    {"date", &setStringValue},       {"time", &setStringValue},     {"domain", &setStringValue},
+    {"type", &setStringValue},       {"levtype", &setStringValue},  {"step", &setInt64Value},
+    {"anoffset", &setInt64Value},    {"levelist", &setInt64Value},  {"param", &setInt64Value},
+    {"experiment", &setStringValue}, {"activity", &setStringValue}, {"generation", &setInt64Value},
+    {"realization", &setInt64Value}, {"model", &setStringValue},    {"resolution", &setStringValue},
+    {"frequency", &setStringValue},  {"direction", &setStringValue},
 };
 }  // namespace
 


### PR DESCRIPTION
With this small edition, MultIO/Maestro now handles the new DestinE data governance, by actually setting CDOs with the new keys.

I just uncommented what we temporarily commented in the beginning of last year, when Maestro was still only supporting the older data governance.

