### PR TITLE
Add includes required by GNU 14.2.0

### DIFF
--- a/src/multio/action/scale/Scaling.h
+++ b/src/multio/action/scale/Scaling.h
@@ -2,7 +2,7 @@
 
 #include <map>
 #include <string>
-
+#include <algorithm>
 #include "eckit/config/LocalConfiguration.h"
 #include "multio/config/ComponentConfiguration.h"
 #include "multio/message/Glossary.h"

--- a/tests/multio/test_multio_mask_compression.cc
+++ b/tests/multio/test_multio_mask_compression.cc
@@ -20,6 +20,7 @@
 
 #include <iomanip>
 #include <random>
+#include <algorithm>
 
 namespace multio::test {
 


### PR DESCRIPTION
These are needed to successfully build IFS with GNU 14.2.0