### PR TITLE
Adding a passthrough mechanism for flushes in select action

### DIFF
--- a/src/multio/action/aggregate/Aggregate.cc
+++ b/src/multio/action/aggregate/Aggregate.cc
@@ -61,11 +61,22 @@ auto Aggregate::flushCount(const Message& msg) {
 bool Aggregate::handleFlush(const Message& msg) {
     // Initialise if need be
     util::ScopedTiming timing{statistics_.actionTiming_};
+    // to allow flushes coming without a domain to direclty pass through.
+    auto domain = msg.metadata().getOpt<std::string>("domain");
+    if(!domain) {
+        return true;
+    }
+    // get domain info if existant
+    const auto& domainMap = domain::Mappings::instance().get(*domain);
 
-    const auto& domainMap = domain::Mappings::instance().get(msg.domain());
     auto flCount = flushCount(msg);
 
-    return domainMap.isComplete() && flCount == domainMap.size();
+    if((domainMap.isComplete() && flCount == domainMap.size()) == true){
+        //if complete, pass through and reset counter
+        flushes_.erase(msg.fieldId());
+        return true;
+    }
+    return false;
 }
 
 bool Aggregate::allPartsArrived(const Message& msg) const {

--- a/src/multio/action/aggregate/Aggregate.cc
+++ b/src/multio/action/aggregate/Aggregate.cc
@@ -71,7 +71,7 @@ bool Aggregate::handleFlush(const Message& msg) {
 
     auto flCount = flushCount(msg);
 
-    if((domainMap.isComplete() && flCount == domainMap.size()) == true){
+    if(domainMap.isComplete() && flCount == domainMap.size()){
         //if complete, pass through and reset counter
         flushes_.erase(msg.fieldId());
         return true;

--- a/src/multio/action/aggregate/Aggregate.cc
+++ b/src/multio/action/aggregate/Aggregate.cc
@@ -62,12 +62,12 @@ bool Aggregate::handleFlush(const Message& msg) {
     // Initialise if need be
     util::ScopedTiming timing{statistics_.actionTiming_};
     // to allow flushes coming without a domain to direclty pass through.
-    auto domain = msg.metadata().getOpt<std::string>("domain");
-    if(!domain) {
+    auto domain = msg.metadata().get<std::string>("domain");
+    if(domain=="global") {
         return true;
     }
     // get domain info if existant
-    const auto& domainMap = domain::Mappings::instance().get(*domain);
+    const auto& domainMap = domain::Mappings::instance().get(domain);
 
     auto flCount = flushCount(msg);
 

--- a/src/multio/action/select/Select.cc
+++ b/src/multio/action/select/Select.cc
@@ -28,7 +28,7 @@ Select::Select(const ComponentConfiguration& compConf) :
 
 void Select::executeImpl(Message msg) {
     //pass through action for everything that is not a field, e.g. Flush
-    if (matches(msg) || (msg.tag() != message::Message::Tag::Field)) {
+    if (matches(msg) || ((msg.tag() != message::Message::Tag::Field) || (msg.tag() != message::Message::Tag::Mask) || (msg.tag() != message::Message::Tag::Domain)) ) {
         executeNext(std::move(msg));
     }
 }

--- a/src/multio/action/select/Select.cc
+++ b/src/multio/action/select/Select.cc
@@ -28,8 +28,13 @@ Select::Select(const ComponentConfiguration& compConf) :
 
 void Select::executeImpl(Message msg) {
     //pass through action for everything that is not a field, e.g. Flush
-    if (matches(msg) || ((msg.tag() != message::Message::Tag::Field) || (msg.tag() != message::Message::Tag::Mask) || (msg.tag() != message::Message::Tag::Domain)) ) {
+    if ((msg.tag() == message::Message::Tag::Flush) || (msg.tag() == message::Message::Tag::Notification)) {
         executeNext(std::move(msg));
+        return;
+    }
+    if ( matches(msg) ) {
+        executeNext(std::move(msg));
+        return;
     }
 }
 

--- a/src/multio/action/select/Select.cc
+++ b/src/multio/action/select/Select.cc
@@ -27,7 +27,8 @@ Select::Select(const ComponentConfiguration& compConf) :
     ChainedAction{compConf}, selectors_{MatchReduce::construct(compConf.parsedConfig())} {}
 
 void Select::executeImpl(Message msg) {
-    if (matches(msg)) {
+    //pass through action for everything that is not a field, e.g. Flush
+    if (matches(msg) || (msg.tag() != message::Message::Tag::Field)) {
         executeNext(std::move(msg));
     }
 }

--- a/src/multio/api/c/multio_capi.cc
+++ b/src/multio/api/c/multio_capi.cc
@@ -460,11 +460,6 @@ int multio_delete_handle(multio_handle_t* mio) {
     return wrapApiFunction([mio]() {
         ASSERT(mio);
 
-        multio::message::Metadata md;
-        md.set("flushKind", "end-of-simulation");
-
-        mio->dispatch(std::move(md), eckit::Buffer{0}, Message::Tag::Flush);
-
         // TODO add sleep
         delete mio;
     });
@@ -508,8 +503,8 @@ int multio_close_connections(multio_handle_t* mio) {
             ASSERT(mio);
 
             multio::message::Metadata md;
-            md.set("flushKind", "end-of-simulation");
-
+            md.set("flushKind", "close-connection");
+            md.set("toAllServers",true);
             mio->dispatch(std::move(md), eckit::Buffer{0}, Message::Tag::Flush);
 
             mio->closeConnections();
@@ -526,7 +521,6 @@ int multio_flush(multio_handle_t* mio, multio_metadata_t* md) {
         [mio, md]() {
             ASSERT(mio);
             ASSERT(md);
-
             mio->dispatch(md->md, multio::message::PayloadReference{nullptr, 0}, Message::Tag::Flush);
         },
         mio);

--- a/src/multio/api/c/multio_capi.cc
+++ b/src/multio/api/c/multio_capi.cc
@@ -505,6 +505,7 @@ int multio_close_connections(multio_handle_t* mio) {
             multio::message::Metadata md;
             md.set("flushKind", "close-connection");
             md.set("toAllServers",true);
+            md.set("domain","global");
             mio->dispatch(std::move(md), eckit::Buffer{0}, Message::Tag::Flush);
 
             mio->closeConnections();


### PR DESCRIPTION
The select action was filtering flushes and didn't pass them through to the next action in the plan. This meant that for almost all plans a flush was not effective and ignored.