### PR TITLE
Feature/improvements for encoding AIFS via multiopython & CaMa Floods

### DIFF
--- a/src/multio/action/encode/Encode.cc
+++ b/src/multio/action/encode/Encode.cc
@@ -62,7 +62,15 @@ GridType createGrid(const std::string& atlasNamedGrid) {
 void updateGaussianGrid(codes_handle* handle, const std::string& atlasNamedGrid) {
     const auto gaussianGrid = createGrid<atlas::GaussianGrid>(atlasNamedGrid);
 
-    int err = codes_set_long(handle, "N", gaussianGrid.N());
+    std::regex reducedGaussianMatch{"^\\s*[O]\\d+\\s*$"};
+    bool isReducedGaussian = std::regex_match(atlasNamedGrid, reducedGaussianMatch);
+    std::string gridType{isReducedGaussian ? "reduced_gg" : "regular_gg"};
+    size_t gridTypeSize = gridType.size();
+    int err = codes_set_string(handle, "gridType", gridType.c_str(), &gridTypeSize);
+    handleCodesError("eccodes error while setting the gridType to reduced_gg/regular_gg", err, Here());
+
+
+    err = codes_set_long(handle, "N", gaussianGrid.N());
     handleCodesError("eccodes error while setting the N value: ", err, Here());
 
     auto tmp = gaussianGrid.nx();
@@ -97,7 +105,13 @@ void updateGaussianGrid(codes_handle* handle, const std::string& atlasNamedGrid)
 
 void updateRegularLatLonGrid(codes_handle* handle, const std::string& atlasNamedGrid) {
     const auto llGrid = createGrid<atlas::RegularLonLatGrid>(atlasNamedGrid);
-    int err = codes_set_long(handle, "Ni", llGrid.nx());
+
+    std::string gridType{"regular_ll"};
+    size_t gridTypeSize = gridType.size();
+    int err = codes_set_string(handle, "gridType", gridType.c_str(), &gridTypeSize);
+    handleCodesError("eccodes error while setting the gridType to regular_ll", err, Here());
+
+    err = codes_set_long(handle, "Ni", llGrid.nx());
     handleCodesError("eccodes error while setting the Ni value: ", err, Here());
     err = codes_set_long(handle, "Nj", llGrid.ny());
     handleCodesError("eccodes error while setting the Nj value: ", err, Here());

--- a/src/multio/action/encode/GribEncoder.cc
+++ b/src/multio/action/encode/GribEncoder.cc
@@ -519,12 +519,12 @@ QueriedMarsKeys setMarsKeys(GribEncoder& g, const Dict& md) {
             std::optional<double> east;
             std::optional<double> westEastInc;
             std::optional<double> southNorthInc;
-            std::optional<double> latitudeOfFirstGridPoint;
-            std::optional<double> longitudeOfFirstGridPoint;
-            std::optional<double> latitudeOfLastGridPoint;
-            std::optional<double> longitudeOfLastGridPoint;
-            std::optional<double> iDirectionIncrement;
-            std::optional<double> jDirectionIncrement;
+            std::optional<double> latitudeOfFirstGridPointInDegrees;
+            std::optional<double> longitudeOfFirstGridPointInDegrees;
+            std::optional<double> latitudeOfLastGridPointInDegrees;
+            std::optional<double> longitudeOfLastGridPointInDegrees;
+            std::optional<double> iDirectionIncrementInDegrees;
+            std::optional<double> jDirectionIncrementInDegrees;
             if ((ni = lookUp<std::int64_t>(md, glossary().ni)()) && (nj = lookUp<std::int64_t>(md, glossary().nj)())
                 && (north = lookUp<double>(md, glossary().north)()) && (south = lookUp<double>(md, glossary().south)())
                 && (west = lookUp<double>(md, glossary().west)()) && (east = lookUp<double>(md, glossary().east)())
@@ -548,20 +548,25 @@ QueriedMarsKeys setMarsKeys(GribEncoder& g, const Dict& md) {
             }
             else if ((ni = lookUp<std::int64_t>(md, glossary().ni)())
                      && (nj = lookUp<std::int64_t>(md, glossary().nj)())
-                     && (latitudeOfFirstGridPoint = lookUp<double>(md, glossary().latitudeOfFirstGridPoint)())
-                     && (latitudeOfLastGridPoint = lookUp<double>(md, glossary().latitudeOfLastGridPoint)())
-                     && (longitudeOfFirstGridPoint = lookUp<double>(md, glossary().longitudeOfFirstGridPoint)())
-                     && (longitudeOfLastGridPoint = lookUp<double>(md, glossary().longitudeOfLastGridPoint)())
-                     && (iDirectionIncrement = lookUp<double>(md, glossary().iDirectionIncrement)())
-                     && (jDirectionIncrement = lookUp<double>(md, glossary().jDirectionIncrement)())) {
+                     && (latitudeOfFirstGridPointInDegrees
+                         = lookUp<double>(md, glossary().latitudeOfFirstGridPointInDegrees)())
+                     && (latitudeOfLastGridPointInDegrees
+                         = lookUp<double>(md, glossary().latitudeOfLastGridPointInDegrees)())
+                     && (longitudeOfFirstGridPointInDegrees
+                         = lookUp<double>(md, glossary().longitudeOfFirstGridPointInDegrees)())
+                     && (longitudeOfLastGridPointInDegrees
+                         = lookUp<double>(md, glossary().longitudeOfLastGridPointInDegrees)())
+                     && (iDirectionIncrementInDegrees = lookUp<double>(md, glossary().iDirectionIncrementInDegrees)())
+                     && (jDirectionIncrementInDegrees
+                         = lookUp<double>(md, glossary().jDirectionIncrementInDegrees)())) {
                 g.setValue("Ni", *ni);
                 g.setValue("Nj", *nj);
-                g.setValue("latitudeOfFirstGridPoint", *latitudeOfFirstGridPoint);
-                g.setValue("longitudeOfFirstGridPoint", *longitudeOfFirstGridPoint);
-                g.setValue("latitudeOfLastGridPoint", *latitudeOfLastGridPoint);
-                g.setValue("longitudeOfLastGridPoint", *longitudeOfLastGridPoint);
-                g.setValue("iDirectionIncrement", *iDirectionIncrement);
-                g.setValue("jDirectionIncrement", *jDirectionIncrement);
+                g.setValue(glossary().latitudeOfFirstGridPointInDegrees, *latitudeOfFirstGridPointInDegrees);
+                g.setValue(glossary().longitudeOfFirstGridPointInDegrees, *longitudeOfFirstGridPointInDegrees);
+                g.setValue(glossary().latitudeOfLastGridPointInDegrees, *latitudeOfLastGridPointInDegrees);
+                g.setValue(glossary().longitudeOfLastGridPointInDegrees, *longitudeOfLastGridPointInDegrees);
+                g.setValue(glossary().iDirectionIncrementInDegrees, *iDirectionIncrementInDegrees);
+                g.setValue(glossary().jDirectionIncrementInDegrees, *jDirectionIncrementInDegrees);
             }
         }
         else if (eckit::StringTools::lower(*gridType) == "healpix") {

--- a/src/multio/action/encode/GribEncoder.cc
+++ b/src/multio/action/encode/GribEncoder.cc
@@ -519,6 +519,12 @@ QueriedMarsKeys setMarsKeys(GribEncoder& g, const Dict& md) {
             std::optional<double> east;
             std::optional<double> westEastInc;
             std::optional<double> southNorthInc;
+            std::optional<double> latitudeOfFirstGridPoint;
+            std::optional<double> longitudeOfFirstGridPoint;
+            std::optional<double> latitudeOfLastGridPoint;
+            std::optional<double> longitudeOfLastGridPoint;
+            std::optional<double> iDirectionIncrement;
+            std::optional<double> jDirectionIncrement;
             if ((ni = lookUp<std::int64_t>(md, glossary().ni)()) && (nj = lookUp<std::int64_t>(md, glossary().nj)())
                 && (north = lookUp<double>(md, glossary().north)()) && (south = lookUp<double>(md, glossary().south)())
                 && (west = lookUp<double>(md, glossary().west)()) && (east = lookUp<double>(md, glossary().east)())
@@ -539,6 +545,23 @@ QueriedMarsKeys setMarsKeys(GribEncoder& g, const Dict& md) {
                 g.setValue("longitudeOfLastGridPoint", scale * (*east - *westEastInc));
                 g.setValue("iDirectionIncrement", scale * *westEastInc);
                 g.setValue("jDirectionIncrement", scale * *southNorthInc);
+            }
+            else if ((ni = lookUp<std::int64_t>(md, glossary().ni)())
+                     && (nj = lookUp<std::int64_t>(md, glossary().nj)())
+                     && (latitudeOfFirstGridPoint = lookUp<double>(md, glossary().latitudeOfFirstGridPoint)())
+                     && (latitudeOfLastGridPoint = lookUp<double>(md, glossary().latitudeOfLastGridPoint)())
+                     && (longitudeOfFirstGridPoint = lookUp<double>(md, glossary().longitudeOfFirstGridPoint)())
+                     && (longitudeOfLastGridPoint = lookUp<double>(md, glossary().longitudeOfLastGridPoint)())
+                     && (iDirectionIncrement = lookUp<double>(md, glossary().iDirectionIncrement)())
+                     && (jDirectionIncrement = lookUp<double>(md, glossary().jDirectionIncrement)())) {
+                g.setValue("Ni", *ni);
+                g.setValue("Nj", *nj);
+                g.setValue("latitudeOfFirstGridPoint", *latitudeOfFirstGridPoint);
+                g.setValue("longitudeOfFirstGridPoint", *longitudeOfFirstGridPoint);
+                g.setValue("latitudeOfLastGridPoint", *latitudeOfLastGridPoint);
+                g.setValue("longitudeOfLastGridPoint", *longitudeOfLastGridPoint);
+                g.setValue("iDirectionIncrement", *iDirectionIncrement);
+                g.setValue("jDirectionIncrement", *jDirectionIncrement);
             }
         }
         else if (eckit::StringTools::lower(*gridType) == "healpix") {

--- a/src/multio/message/Glossary.h
+++ b/src/multio/message/Glossary.h
@@ -237,12 +237,22 @@ struct Glossary {
     // Regular ll
     const KeyType ni{"Ni"};
     const KeyType nj{"Nj"};
+
+    // Regular ll - mapped
     const KeyType north{"north"};
     const KeyType west{"west"};
     const KeyType south{"south"};
     const KeyType east{"east"};
     const KeyType westEastIncrement{"west_east_increment"};
     const KeyType southNorthIncrement{"south_north_increment"};
+
+    // Regular ll - direct
+    const KeyType latitudeOfFirstGridPoint{"latitudeOfFirstGridPoint"};
+    const KeyType latitudeOfLastGridPoint{"latitudeOfLastGridPoint"};
+    const KeyType longitudeOfFirstGridPoint{"longitudeOfFirstGridPoint"};
+    const KeyType longitudeOfLastGridPoint{"longitudeOfLastGridPoint"};
+    const KeyType jDirectionIncrement{"jDirectionIncrement"};
+    const KeyType iDirectionIncrement{"iDirectionIncrement"};
 
 
     static const Glossary& instance() {

--- a/src/multio/message/Glossary.h
+++ b/src/multio/message/Glossary.h
@@ -247,12 +247,12 @@ struct Glossary {
     const KeyType southNorthIncrement{"south_north_increment"};
 
     // Regular ll - direct
-    const KeyType latitudeOfFirstGridPoint{"latitudeOfFirstGridPoint"};
-    const KeyType latitudeOfLastGridPoint{"latitudeOfLastGridPoint"};
-    const KeyType longitudeOfFirstGridPoint{"longitudeOfFirstGridPoint"};
-    const KeyType longitudeOfLastGridPoint{"longitudeOfLastGridPoint"};
-    const KeyType jDirectionIncrement{"jDirectionIncrement"};
-    const KeyType iDirectionIncrement{"iDirectionIncrement"};
+    const KeyType latitudeOfFirstGridPointInDegrees{"latitudeOfFirstGridPointInDegrees"};
+    const KeyType latitudeOfLastGridPointInDegrees{"latitudeOfLastGridPointInDegrees"};
+    const KeyType longitudeOfFirstGridPointInDegrees{"longitudeOfFirstGridPointInDegrees"};
+    const KeyType longitudeOfLastGridPointInDegrees{"longitudeOfLastGridPointInDegrees"};
+    const KeyType jDirectionIncrementInDegrees{"jDirectionIncrementInDegrees"};
+    const KeyType iDirectionIncrementInDegrees{"iDirectionIncrementInDegrees"};
 
 
     static const Glossary& instance() {


### PR DESCRIPTION
Just a few changes that should not break existing behaviour:

* when applying grid information from an atlas grid, the gridType is now applied to change the underlying grid template - before the sample must have set already a suitable template
* CaMa Floods is using regular_ll - currently we compute first/last long/lat from fields like "north", "west"... isntead of setting "latitudeOfFirstGridPoint"... directly