### PR TITLE
Pass bitmapPresent and missingValue in multio-feed

### DIFF
--- a/src/multio/action/interpolate/Interpolate.cc
+++ b/src/multio/action/interpolate/Interpolate.cc
@@ -456,7 +456,7 @@ message::Message Interpolate::InterpolateMessage<double>(message::Message&& msg)
     fill_input(config, inputPar, size, msg.metadata().getOpt<std::string>(glossary().domain).value_or(""), inp);
     auto searchMissingValue = msg.metadata().find("missingValue");
     auto searchBitmapPresent = msg.metadata().find("bitmapPresent");
-    if (searchMissingValue != msg.metadata().end() && searchBitmapPresent != msg.metadata().end()) {
+    if (searchMissingValue != msg.metadata().end() && searchBitmapPresent != msg.metadata().end() && searchBitmapPresent->second.get<bool>()) {
         inputPar.set("missing_value", searchMissingValue->second.get<double>());
     }
     else if (config.getSubConfiguration("options").has("missing_value")) {

--- a/src/multio/tools/multio-feed.cc
+++ b/src/multio/tools/multio-feed.cc
@@ -292,6 +292,14 @@ void MultioFeed::execute(const eckit::option::CmdArgs& args) {
                 metadata.set("step-frequency", 1);
             }
 
+            // Metadata required to handle missing values in statistics and interpolation
+            if (metadataDetailed.has("bitmapPresent")) {
+                metadata.set("bitmapPresent", metadataDetailed.getBool("bitmapPresent"));
+            }
+            if (metadataDetailed.has("missingValue")) {
+                metadata.set("missingValue", metadataDetailed.getDouble("missingValue"));
+            }
+
             // Multio pipelines require hhmmss format
             if (metadata.has("time")) {
                 auto time = metadata.getLong("time");


### PR DESCRIPTION
Also updated the interpolate action, since it shouldn't pass the missingValue to MIR if bitmapPresent is false.