### PR TITLE
Adding the option to print values in the print action

### DIFF
--- a/src/multio/action/print/Print.h
+++ b/src/multio/action/print/Print.h
@@ -32,7 +32,9 @@ private:
     void print(std::ostream& os) const override;
 
     bool onlyFields_;
+    bool includeValues_;
     std::string stream_;
+    int numberOfValues_;
 
     std::ostream* os_;
     std::string prefix_;


### PR DESCRIPTION
This is something I sometimes used when debugging actions. I also have a different version in another branch, where I added an option to output just flushes. I will add this in another PR as it's orthogonal. Need to write a test to move from draft to mergable, unless you all decide you don't want this option in the print action
How it works:
  - type: print
    prefix: "Prefix"
    stream: cout
    include-data-values: true 
    value-count: 10