### PR TITLE
Replace all curly during multio configuration initialization

### DIFF
--- a/src/multio/action/encode/Encode.cc
+++ b/src/multio/action/encode/Encode.cc
@@ -136,20 +136,14 @@ std::unique_ptr<GribEncoder> makeEncoder(const eckit::LocalConfiguration& conf,
 
     if (format == "grib") {
         ASSERT(conf.has("template"));
-        std::string tmplPath = conf.getString("template");
         // TODO provide utility to distinguish between relative and absolute paths
-        eckit::AutoStdFile fin{multioConfig.replaceCurly(tmplPath)};
+        eckit::AutoStdFile fin{conf.getString("template")};
         int err;
         auto sample = codes_handle_new_from_file(nullptr, fin, PRODUCT_GRIB, &err);
         handleCodesError("eccodes error while reading the grib template: ", err, Here());
 
         if (conf.has("atlas-named-grid")) {
-            const auto atlasNamedGrid
-                = util::replaceCurly(conf.getString("atlas-named-grid"), [](std::string_view replace) {
-                      std::string lookUpKey{replace};
-                      char* env = ::getenv(lookUpKey.c_str());
-                      return env ? std::optional<std::string>{env} : std::optional<std::string>{};
-                  });
+            const auto atlasNamedGrid = conf.getString("atlas-named-grid");
 
             eckit::Log::info() << "REQUESTED ATLAS GRID DEFINITION UPDATE: " << atlasNamedGrid << std::endl;
 

--- a/src/multio/action/encode/GribEncoder.cc
+++ b/src/multio/action/encode/GribEncoder.cc
@@ -238,8 +238,7 @@ std::optional<ValueSetter> valueSetter(GribEncoder& g, const std::string& key) {
 }
 
 std::string getUnstructuredGridType(const eckit::LocalConfiguration& config) {
-    std::optional<std::string_view> (*F)(std::string_view) = &multio::util::getEnv;
-    return multio::util::replaceCurly(config.getString("unstructured-grid-type"), F);
+    return config.getString("unstructured-grid-type");
 }
 
 }  // namespace

--- a/src/multio/action/encode/GridDownloader.cc
+++ b/src/multio/action/encode/GridDownloader.cc
@@ -42,9 +42,7 @@ std::unique_ptr<multio::action::GribEncoder> createEncoder(const multio::config:
                               << std::endl;
         return nullptr;
     }
-    const auto tmplPath = compConf.parsedConfig().getString("grid-downloader-template");
-
-    eckit::AutoStdFile fin{compConf.multioConfig().replaceCurly(tmplPath)};
+    eckit::AutoStdFile fin{compConf.parsedConfig().getString("grid-downloader-template")};
 
     int err = 0;
     auto encoder = std::make_unique<multio::action::GribEncoder>(
@@ -64,8 +62,7 @@ atlas::Grid readGrid(const std::string& name) {
 }
 
 std::string getUnstructuredGridType(const multio::config::ComponentConfiguration& compConf) {
-    std::optional<std::string_view> (*F)(std::string_view) = &multio::util::getEnv;
-    return multio::util::replaceCurly(compConf.parsedConfig().getString("unstructured-grid-type"), F);
+    return compConf.parsedConfig().getString("unstructured-grid-type");
 }
 
 }  // namespace

--- a/src/multio/action/interpolate-fesom/InterpolateFesom.cc
+++ b/src/multio/action/interpolate-fesom/InterpolateFesom.cc
@@ -59,13 +59,11 @@ void fill_metadata(const message::Metadata& in_md, message::Metadata& out_md, si
     return;
 };
 
+// TODO: Consider removing this function!
+// fname comes from an already expanded configuration.
 std::string fullFileName(const std::string& fname) {
     if (fname != "none") {
-        const std::string fullFname = util::replaceCurly(fname, [](std::string_view replace) {
-            std::string lookUpKey{replace};
-            char* env = ::getenv(lookUpKey.c_str());
-            return env ? std::optional<std::string>{env} : std::optional<std::string>{};
-        });
+        const std::string fullFname = util::replaceCurly(fname);
         eckit::PathName tmp{fullFname};
         if (!tmp.exists()) {
             std::ostringstream os;

--- a/src/multio/action/renumber-healpix/HEALPix_ring2nest.cc
+++ b/src/multio/action/renumber-healpix/HEALPix_ring2nest.cc
@@ -43,7 +43,7 @@ std::string parseCacheFileName(const ComponentConfiguration& compConf) {
     }
 
     // Expand file name
-    const auto cacheFileName = compConf.multioConfig().replaceCurly(cfg.getString("cache-file-name"));
+    const auto cacheFileName = cfg.getString("cache-file-name");
 
     // Check existence of the cache file
     eckit::PathName tmp{cacheFileName};

--- a/src/multio/action/statistics/cfg/StatisticsOptions.cc
+++ b/src/multio/action/statistics/cfg/StatisticsOptions.cc
@@ -150,14 +150,12 @@ void StatisticsOptions::parseRestartPath(const config::ComponentConfiguration& c
                                          const eckit::LocalConfiguration& cfg) {
     // Read the path used to restart statistics
     // Default value is "."
-    if (cfg.has("restart-path")) {
-        restartPath_ = compConf.multioConfig().replaceCurly(cfg.getString("restart-path", "."));
-        eckit::PathName path{restartPath_};
-        if (!path.exists() || !path.isDir()) {
-            std::ostringstream os;
-            os << "Restart path does not exist :: " << restartPath_ << std::endl;
-            throw eckit::UserError{os.str(), Here()};
-        }
+    restartPath_ = cfg.getString("restart-path", ".");
+    eckit::PathName path{restartPath_};
+    if (!path.exists() || !path.isDir()) {
+        std::ostringstream os;
+        os << "Restart path does not exist :: " << restartPath_ << std::endl;
+        throw eckit::UserError{os.str(), Here()};
     }
     return;
 };
@@ -167,9 +165,7 @@ void StatisticsOptions::parseRestartTime(const config::ComponentConfiguration& c
                                          const eckit::LocalConfiguration& cfg) {
     // Read the path used to restart statistics
     // Default value is "latest"
-    if (cfg.has("restart-time")) {
-        restartTime_ = compConf.multioConfig().replaceCurly(cfg.getString("restart-time", "latest"));
-    }
+    restartTime_ = cfg.getString("restart-time", "latest");
     return;
 };
 
@@ -178,7 +174,7 @@ void StatisticsOptions::parseRestartPrefix(const config::ComponentConfiguration&
                                            const eckit::LocalConfiguration& cfg) {
     // Prefix used for the restart file names in order
     // to make the file name unique across different plans
-    restartPrefix_ = compConf.multioConfig().replaceCurly(cfg.getString("restart-prefix", "StatisticsDump"));
+    restartPrefix_ = cfg.getString("restart-prefix", "StatisticsDump");
     return;
 };
 
@@ -222,7 +218,7 @@ void StatisticsOptions::parseSolverResetAccumulatedFields(const config::Componen
 
 void StatisticsOptions::parseValueCountThreshold(const config::ComponentConfiguration& compConf,
                                                  const eckit::LocalConfiguration& cfg) {
-    long threshold = stol(compConf.multioConfig().replaceCurly(cfg.getString("value-count-threshold", "-1")));
+    long threshold = cfg.getLong("value-count-threshold", -1);
 
     if (threshold == -1) {
         valueCountThreshold_ = std::nullopt;

--- a/src/multio/config/MetadataMappings.cc
+++ b/src/multio/config/MetadataMappings.cc
@@ -34,16 +34,6 @@ const std::vector<message::MetadataMapping>& MetadataMappings::getMappings(const
 
         std::vector<eckit::LocalConfiguration> sourceList = configFile.content.getSubConfigurations("data");
 
-        for (auto& s : sourceList) {
-            for (auto& key : s.keys()) {
-                // Replace the value if it is string
-                if (s.isString(key)) {
-                    s.set(key, multioConf.replaceCurly(s.getString(key)));
-                }
-            }
-        }
-
-
         // Evaluate mappings block
         if (!configFile.content.has("mappings")) {
             std::ostringstream oss;

--- a/src/multio/config/MultioConfiguration.h
+++ b/src/multio/config/MultioConfiguration.h
@@ -138,6 +138,9 @@ private:
     MultioConfiguration(const eckit::LocalConfiguration& globalConfig, const eckit::PathName& configDir,
                         const eckit::PathName& configFile, LocalPeerTag clientOrServer = LocalPeerTag::Client);
 
+    void replaceAllCurly(eckit::LocalConfiguration& cfg) const;
+    eckit::LocalConfiguration replaceAllCurly(const eckit::LocalConfiguration& cfg) const;
+
     eckit::LocalConfiguration parsedConfig_;
     eckit::PathName configDir_;
     eckit::PathName configFile_;

--- a/src/multio/config/PlanConfiguration.cc
+++ b/src/multio/config/PlanConfiguration.cc
@@ -292,29 +292,16 @@ eckit::LocalConfiguration parseDisseminationFile(const eckit::LocalConfiguration
     sId = s.str();
 
     // Get templates Path
-    std::string templatesPath;
-    if (componentConfig.has("templates-path")) {
-        templatesPath = multioConf.replaceCurly(componentConfig.getString("templates-path"));
-        if (!eckit::PathName{templatesPath}.exists()) {
-            std::ostringstream oss;
-            oss << "templates path not exists";
-            throw eckit::UserError(oss.str(), Here());
-        }
-    }
-    else {
-        templatesPath = ".";
+    const auto templatesPath = componentConfig.getString("templates-path", ".");
+    if (!eckit::PathName{templatesPath}.exists()) {
+        std::ostringstream oss;
+        oss << "templates path does not exists";
+        throw eckit::UserError(oss.str(), Here());
     }
 
 
     // Get templates Path
-    std::string outputPath;
-    if (componentConfig.has("output-path")) {
-        outputPath = multioConf.replaceCurly(componentConfig.getString("output-path"));
-    }
-    else {
-        outputPath = ".";
-    }
-    outputPath = outputPath + "/" + planName + "/" + sId;
+    std::string outputPath = componentConfig.getString("output-path", ".") + "/" + planName + "/" + sId;
     eckit::PathName{outputPath}.mkdir();
 
     // The objective is to construct something like this starting from a metkit mars request
@@ -434,7 +421,7 @@ std::vector<eckit::LocalConfiguration> buildDisseminationPlan(const eckit::Local
                                                               const MultioConfiguration& multioConf) {
 
     // Get the name of the dissemination file
-    std::string disseminationFile = multioConf.replaceCurly(componentConfig.getString("dissemination"));
+    std::string disseminationFile = componentConfig.getString("dissemination");
 
     // Create plans
     std::vector<eckit::LocalConfiguration> rawPlans
@@ -458,7 +445,7 @@ std::vector<eckit::LocalConfiguration> configurePlans(const eckit::LocalConfigur
     eckit::LocalConfiguration cfg;
     std::string name;
     if (componentConfig.has("file")) {
-        const std::string fname = multioConf.replaceCurly(componentConfig.getString("file"));
+        const std::string fname = componentConfig.getString("file");
         const auto& file = multioConf.getConfigFile(fname);
         cfg = file.content;
         // Force the name in the plan configuration

--- a/src/multio/fdb5/FDB5Sink.cc
+++ b/src/multio/fdb5/FDB5Sink.cc
@@ -27,25 +27,8 @@ using config::ComponentConfiguration;
 
 namespace {
 
-void replaceCurly(const ComponentConfiguration& compConf, eckit::LocalConfiguration& cfg) {
-    for (auto& key : cfg.keys()) {
-        // Replace the value if it is string
-        if (cfg.isString(key)) {
-            cfg.set(key, compConf.multioConfig().replaceCurly(cfg.getString(key)));
-        }
-        // Recursive replace of curly brackets
-        if (cfg.isSubConfiguration(key)) {
-            auto tmp = cfg.getSubConfiguration(key);
-            replaceCurly(compConf, tmp);
-            cfg.set(key, tmp);
-        }
-    }
-    return;
-}
-
 fdb5::Config fdb5_configuration(const ComponentConfiguration& compConf) {
     auto fdb_configuration = compConf.parsedConfig().getSubConfiguration("config");
-    replaceCurly(compConf, fdb_configuration);
 
     eckit::LocalConfiguration userConfig;
     if (fdb_configuration.has("userConfig")) {

--- a/src/multio/sink/FileSink.cc
+++ b/src/multio/sink/FileSink.cc
@@ -30,14 +30,13 @@ namespace {
 std::string create_path(const config::ComponentConfiguration& compConf) {
     const auto& cfg = compConf.parsedConfig();
     auto path = cfg.getString("path");
-    auto expanded_path = compConf.multioConfig().replaceCurly(path);
-    eckit::Log::info() << "path = " << expanded_path << std::endl;
+    eckit::Log::info() << "path = " << path << std::endl;
     if (cfg.getBool("per-server", false)) {
-        eckit::PathName tmp = expanded_path;
-        auto dirName = tmp.baseName().asString() == expanded_path ? "" : tmp.dirName().asString() + "/";
+        eckit::PathName tmp = path;
+        auto dirName = tmp.baseName().asString() == path ? "" : tmp.dirName().asString() + "/";
         return dirName + util::filename_prefix() + "-" + tmp.baseName().asString();
     }
-    return expanded_path;
+    return path;
 }
 }  // namespace
 

--- a/src/multio/util/Substitution.h
+++ b/src/multio/util/Substitution.h
@@ -70,6 +70,7 @@ std::string replaceCurly(std::string_view s, Func&& lookup) {
     }
 }
 
+std::string replaceCurly(std::string_view s);
 
 std::optional<bool> parseBool(const eckit::LocalConfiguration& cfg, const std::string& key, bool defaultValue);
 std::optional<bool> parseEnabled(const eckit::LocalConfiguration& cfg, bool defaultValue);


### PR DESCRIPTION
Instead of having to call replace curly for each option separately, this change will expand all the curly brackets for every string value when the multio configuraiton is initialized.