### PR TITLE
Change GEO_PAR_T ISMAX to int(9)

### DIFF
--- a/src/multiom/encoders/encoder-grib2/grib2-section4/grib2-model-configurator/grib2_section4_model_mod.F90
+++ b/src/multiom/encoders/encoder-grib2/grib2-section4/grib2-model-configurator/grib2_section4_model_mod.F90
@@ -725,7 +725,7 @@ IMPLICIT NONE
               CALL GRIB_IS_DEFINED( HANDLE, 'localDefinitionNumber', IS_DEFINED, STATUS=KRET )
               PP_DEBUG_CRITICAL_COND_THROW( KRET.NE.GRIB_SUCCESS , ERRFLAG_UNABLE_TO_CHECK_IS_DEFINED )
 
-              IF( IS_DEFINED.GT.0 ) THEN
+              IF( IS_DEFINED.NE.0 ) THEN
                   LOCAL_DEFINITION=0_JPIM_K
                   KRET=GRIB_SUCCESS
                   CALL GRIB_GET( HANDLE, 'localDefinitionNumber', LOCAL_DEFINITION, STATUS=KRET )
@@ -936,7 +936,7 @@ IMPLICIT NONE
               CALL GRIB_IS_DEFINED( HANDLE, 'localDefinitionNumber', IS_DEFINED, STATUS=KRET )
               PP_DEBUG_CRITICAL_COND_THROW( KRET.NE.GRIB_SUCCESS , ERRFLAG_UNABLE_TO_CHECK_IS_DEFINED )
 
-              IF( IS_DEFINED.GT.0 ) THEN
+              IF( IS_DEFINED.NE.0 ) THEN
                   LOCAL_DEFINITION=0_JPIM_K
                   KRET=GRIB_SUCCESS
                   CALL GRIB_GET( HANDLE, 'localDefinitionNumber', LOCAL_DEFINITION, STATUS=KRET )

--- a/src/multiom/encoders/encoder-grib2/grib2-section4/grib2-model-configurator/grib2_section4_model_mod.F90
+++ b/src/multiom/encoders/encoder-grib2/grib2-section4/grib2-model-configurator/grib2_section4_model_mod.F90
@@ -725,7 +725,7 @@ IMPLICIT NONE
               CALL GRIB_IS_DEFINED( HANDLE, 'localDefinitionNumber', IS_DEFINED, STATUS=KRET )
               PP_DEBUG_CRITICAL_COND_THROW( KRET.NE.GRIB_SUCCESS , ERRFLAG_UNABLE_TO_CHECK_IS_DEFINED )
 
-              IF( IS_DEFINED) THEN
+              IF( IS_DEFINED.GT.0 ) THEN
                   LOCAL_DEFINITION=0_JPIM_K
                   KRET=GRIB_SUCCESS
                   CALL GRIB_GET( HANDLE, 'localDefinitionNumber', LOCAL_DEFINITION, STATUS=KRET )
@@ -936,7 +936,7 @@ IMPLICIT NONE
               CALL GRIB_IS_DEFINED( HANDLE, 'localDefinitionNumber', IS_DEFINED, STATUS=KRET )
               PP_DEBUG_CRITICAL_COND_THROW( KRET.NE.GRIB_SUCCESS , ERRFLAG_UNABLE_TO_CHECK_IS_DEFINED )
 
-              IF( IS_DEFINED) THEN
+              IF( IS_DEFINED.GT.0 ) THEN
                   LOCAL_DEFINITION=0_JPIM_K
                   KRET=GRIB_SUCCESS
                   CALL GRIB_GET( HANDLE, 'localDefinitionNumber', LOCAL_DEFINITION, STATUS=KRET )

--- a/src/multiom/ifs-interface/ifs_par_mod.F90
+++ b/src/multiom/ifs-interface/ifs_par_mod.F90
@@ -12,6 +12,7 @@ MODULE IFS_PAR_MOD
 
   ! Symbols imported from other modules within the project.
   USE :: DATAKINDS_DEF_MOD, ONLY: JPIB_K
+  USE :: DATAKINDS_DEF_MOD, ONLY: JPIM_K
   USE :: DATAKINDS_DEF_MOD, ONLY: JPRD_K
 
 IMPLICIT NONE
@@ -229,7 +230,7 @@ TYPE :: GEO_PAR_T
   ! yomdim.F90 - Geometry dimensions
   ! --------------------------------
   ! NSMAX   : truncation order
-  INTEGER(KIND=JPIB_K) :: ISMAX
+  INTEGER(KIND=JPIM_K) :: ISMAX
   ! NDGLG  : number of rows of latitudes
   INTEGER(KIND=JPIB_K) :: ILATS
   ! NDLON  : length of a row of latitude near equator


### PR DESCRIPTION
The cray compiler complains with the current int(12) when ISMAX is a parameter for ifsaux FITSPECTRUM where KSMAX is defined as int(9). Changing it here to also be int(9) allows the code to build.