### PR TITLE
Bug/pylib release

### DIFF
--- a/.github/workflows/build-wheel-wrapper.yml
+++ b/.github/workflows/build-wheel-wrapper.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   python-wrapper-wheel:
     name: Python Wrapper Wheel
-    uses: ecmwf/reusable-workflows/.github/workflows/python-wrapper-wheel.yml@main
+    uses: ecmwf/reusable-workflows/.github/workflows/python-wrapper-wheel.yml@act/pyWrapWheel/fixVenvs
     with:
       wheel_directory: python/multiolib
     secrets: inherit

--- a/.github/workflows/build-wheel-wrapper.yml
+++ b/.github/workflows/build-wheel-wrapper.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   python-wrapper-wheel:
     name: Python Wrapper Wheel
-    uses: ecmwf/reusable-workflows/.github/workflows/python-wrapper-wheel.yml@act/pyWrapWheel/fixVenvs
+    uses: ecmwf/reusable-workflows/.github/workflows/python-wrapper-wheel.yml@main
     with:
       wheel_directory: python/multiolib
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ dependencies = [
   "pyyaml",
   "numpy",
   "findlibs",
+  "multiolib",
 ]
 
 optional-dependencies.all = [ "pymultio" ]

--- a/python/multiolib/buildconfig
+++ b/python/multiolib/buildconfig
@@ -11,8 +11,8 @@
 # TODO we duplicate information -- pyproject.toml's `name` and `packages` are derivable from $NAME and must stay consistent
 
 NAME="multio"
-CMAKE_PARAMS1="-Deckit_ROOT=/tmp/multio/prereqs/eckitlib -Deccodes_ROOT=/tmp/multio/prereqs/eccodeslib -Dmetkit_ROOT=/tmp/multio/prereqs/metkitlib -Datlas_ROOT=/tmp/multio/prereqs/atlaslib -Dfdb5_ROOT=/tmp/multio/prereqs/fdblib -Dmir_ROOT=/tmp/multio/prereqs/mirlib -Dfckit_ROOT=/tmp/multio/prereqs/fckitlib"
+CMAKE_PARAMS1="-Deckit_ROOT=/tmp/multio/prereqs/eckitlib -Deccodes_ROOT=/tmp/multio/prereqs/eccodeslib -Dmetkit_ROOT=/tmp/multio/prereqs/metkitlib -Datlas_ROOT=/tmp/multio/prereqs/atlaslib-ecmwf -Dfdb5_ROOT=/tmp/multio/prereqs/fdb5lib -Dmir_ROOT=/tmp/multio/prereqs/mirlib -Dfckit_ROOT=/tmp/multio/prereqs/fckitlib"
 CMAKE_PARAMS2="-DENABLE_ATLAS_IO=1"
 CMAKE_PARAMS="$CMAKE_PARAMS1 $CMAKE_PARAMS2"
 PYPROJECT_DIR="python/multiolib"
-DEPENDENCIES='["eckitlib", "eccodeslib", "metkitlib", "atlaslib", "fdblib", "mirlib", "fckitlib"]'
+DEPENDENCIES='["eckitlib", "eccodeslib", "metkitlib", "atlaslib-ecmwf", "fdb5lib", "mirlib", "fckitlib"]'

--- a/python/pymultio/src/multio/lib.py
+++ b/python/pymultio/src/multio/lib.py
@@ -43,7 +43,7 @@ class PatchedLib:
     def __init__(self):
         ffi.cdef(self.__read_header())
 
-        libname = findlibs.find("multio-api")
+        libname = findlibs.find("multio-api", "multiolib")
         self.__lib = None
 
         if libname is None:


### PR DESCRIPTION
1/ Fixes a few bugs on the multiolib wheel building
2/ Makes multiolib a dependency of pymultio. Given how everything is built so far, this would require pymultio installs to be done as `pip install --prerelease=allow pymultio`. The need for extra flag would go away once multio and _all_ of its prerequisites would be released (in the sense of `develop->main` merge) and a new wheel built for them (in the sense of running the corresponding github action)