### PR TITLE
Re-enable version check

### DIFF
--- a/.github/ci-hpc-config-pymultio.yml
+++ b/.github/ci-hpc-config-pymultio.yml
@@ -21,3 +21,4 @@ build:
     - CTEST_PARALLEL_LEVEL=1
     - ECCODES_SAMPLES_PATH=$ECCODES_DIR/share/eccodes/samples
     - ECCODES_DEFINITION_PATH=$ECCODES_DIR/share/eccodes/definitions
+    - FINDLIBS_DISABLE_PACKAGE=yes

--- a/python/pymultio/tests/test_multio_pythonapi.py
+++ b/python/pymultio/tests/test_multio_pythonapi.py
@@ -44,6 +44,10 @@ def test_initialisation():
     multio.Multio(**default_dict)
 
 
+def test_multio_version():
+    assert multio.Multio(**default_dict).__version__() == "2.5.0"
+
+
 def test_initialisation_no_config():
     multio.Multio()
 


### PR DESCRIPTION
Let's compare versions with the compiled library for now, until the python wheels are more mature.