### PR TITLE
Extend cd-pypi gh action

### DIFF
--- a/.github/workflows/build-wheel-wrapper.yml
+++ b/.github/workflows/build-wheel-wrapper.yml
@@ -13,10 +13,8 @@ on:
   # Trigger the workflow manually
   workflow_dispatch: ~
 
-  # Allow to be called from another workflow
+  # Allow to be called from another workflow -- currently from cd-pypi
   workflow_call: ~
-
-  # TODO automation trigger
 
 jobs:
   python-wrapper-wheel:

--- a/.github/workflows/cd-pypi.yml
+++ b/.github/workflows/cd-pypi.yml
@@ -6,6 +6,15 @@ on:
     - '**'
 
 jobs:
+  # NOTE the dependency between deploy and python-wrapper-wheel is indirect -- the latter
+  # would presumably succeed if the former fails, but that would mean unsatisfiable wheel
+  # released
+  # TODO check that tag equals VERSION -- otherwise we risk mismatch
+  python-wrapper-wheel:
+    uses: ./.github/workflows/build-wheel-wrapper.yml
+    secrets: inherit
   deploy:
     uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@v2
     secrets: inherit
+    needs:
+      - python-wrapper-wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "pyyaml",
   "numpy",
   "findlibs",
-  "multiolib",
+  "multiolib", # TODO we need to make this dynamic, effectively pin to the exact version
 ]
 
 optional-dependencies.all = [ "pymultio" ]
@@ -71,13 +71,16 @@ urls.Repository = "https://github.com/ecmwf/multio/"
 
 
 [tool.setuptools]
-packages = ["multio"]
-package-dir = { "multio" = "./python/pymultio/src/multio" }
 include-package-data = true
 zip-safe = true
 
+[tool.setuptools.packages.find]
+include = ["multio*"]
+where = ["./python/pymultio/src"]
+
 [tool.setuptools_scm]
 version_file = "./python/pymultio/src/multio/_version.py"
+local_scheme = "no-local-version"
 
 [tool.setuptools.package-data]
 multio = ["*.h"]


### PR DESCRIPTION
1/ fixes a bug that allows the built wheels published to test pypi with dev versions
2/ fixes a bug that would not include `multio.plans` in the resulting wheel
3/ extends the action to first built the wrapper `multiolib`, and only in success the `pymultio`

demonstrated by succeeding in test-pypi https://test.pypi.org/project/pymultio/2.4.1.dev5/#files (note the multiolib actually ended up on regular pypi dev channel, but thats legit)

there are two missing pieces:
1/ we want to check, at the start of the workflow invocation, that `tag == VERSION`, because `multiolib` picks the latter and `pymultio` the former. Alternatively, we could rework `pymultio` to pick the latter as well instead
2/ we need to propagate the version pin of `multiolib` to `pymultio`. This one may be tricky to handle correctly, we may have to drop the `dependencies` section from pyproject and rely on dynamic read in the setup.py

neither is critical for today tho -- the released `pymultio` wheel is legit, it's just about making it safer / more robust
