### PR TITLE
Bugfix/uninitialized pointer

### DIFF
--- a/src/multio/action/encode-mtg2/EncodeMtg2.cc
+++ b/src/multio/action/encode-mtg2/EncodeMtg2.cc
@@ -182,7 +182,7 @@ void* MultiOMDict::get() {
 }
 
 
-MultiOMEncoder::MultiOMEncoder(MultiOMDict& options) {
+MultiOMEncoder::MultiOMEncoder(MultiOMDict& options) : encoder_{nullptr} {
     ASSERT(multio_grib2_encoder_open(options.get(), &encoder_) == 0);
 }
 

--- a/src/multio/action/encode-mtg2/EncodeMtg2.cc
+++ b/src/multio/action/encode-mtg2/EncodeMtg2.cc
@@ -113,7 +113,7 @@ std::string multiOMDictKindString(MultiOMDictKind kind) {
     }
 }
 
-MultiOMDict::MultiOMDict(MultiOMDictKind kind): dict_{NULL},kind_{kind} {
+MultiOMDict::MultiOMDict(MultiOMDictKind kind): dict_{nullptr}, kind_{kind} {
     std::string kindStr = multiOMDictKindString(kind);
     ASSERT(multio_grib2_dict_create(&dict_, kindStr.data()) == 0);
 


### PR DESCRIPTION
Initialize pointer `encoder_`, otherwise a check on the Fortran side will fail because it is sometimes not null!