### PR TITLE
Change pymultio versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ docs/_build
 __pycache__
 *.egg-info
 *.ipynb_checkpoints
-
-_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ testpaths = [
 ]
 
 [build-system]
-requires = [ "setuptools>=65", "setuptools-scm>=8" ]
+requires = [ "setuptools>=80" ]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -74,13 +74,12 @@ urls.Repository = "https://github.com/ecmwf/multio/"
 include-package-data = true
 zip-safe = true
 
+[tool.setuptools.dynamic]
+version = { file = ["VERSION"] }
+
 [tool.setuptools.packages.find]
 include = ["multio*"]
 where = ["./python/pymultio/src"]
-
-[tool.setuptools_scm]
-version_file = "./python/pymultio/src/multio/_version.py"
-local_scheme = "no-local-version"
 
 [tool.setuptools.package-data]
 multio = ["*.h"]

--- a/python/pymultio/src/multio/_version.py
+++ b/python/pymultio/src/multio/_version.py
@@ -1,0 +1,4 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("pymetkit")
+


### PR DESCRIPTION
Originally setuptools_scm was used for versioning the pymultio wheel. I'm switching that to using the VERSION file -- to have it aligned with multio itself as well the multiolib python wheel.

This is needed in particular for our custom `.devYMD` releases.

The `_version.py` is, for simplicity, changed to dynamically read via `importlib.metadata`, instead of static hardcoded version at build time.

Tested via local build, will run a multiple-wheel-release later today -- ideally this is merged by then.