### PR TITLE
Fix in pymultio.__version__

### DIFF
--- a/python/pymultio/src/multio/_version.py
+++ b/python/pymultio/src/multio/_version.py
@@ -1,4 +1,3 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version("pymetkit")
-
+__version__ = importlib.metadata.version("pymultio")


### PR DESCRIPTION
A typo I've caused, apologies. Causes wrong number to be reported internally via `multio.__version__`. But on the wheel metadata level the version is declared fine