### PR TITLE
Fix tests not passing in isolation and parallel

### DIFF
--- a/tests/multio/CMakeLists.txt
+++ b/tests/multio/CMakeLists.txt
@@ -209,81 +209,90 @@ ecbuild_get_test_multidata( EXTRACT TARGET multio_replay_get_test_data
                             NAMES ${_nemo_test_data}
 )
 
-ecbuild_add_test( TARGET        test_multio_replay_nemo_capi_initfilepath_empi
-                  COMMAND       ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
-                  TEST_REQUIRES multio_replay_get_test_data
-                  ARGS          "$<TARGET_FILE:multio-replay-nemo-capi> --init-mpi-external=1 --config-file=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server.yaml"
-                                $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
-                  ENVIRONMENT   "${_test_environment}"
+ecbuild_add_test( TARGET          test_multio_replay_nemo_capi_initfilepath_empi
+                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
+                  TEST_REQUIRES   multio_replay_get_test_data
+                  ARGS            "$<TARGET_FILE:multio-replay-nemo-capi> --init-mpi-external=1 --config-file=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server.yaml"
+                                  $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
+                  ENVIRONMENT     "${_test_environment}"
+                  TEST_PROPERTIES RESOURCE_LOCK mpi
 )
 
-ecbuild_add_test( TARGET        test_multio_replay_nemo_capi_initdefault_empi
-                  COMMAND       ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
-                  TEST_REQUIRES multio_replay_get_test_data
-                  ARGS          "$<TARGET_FILE:multio-replay-nemo-capi> --init-mpi-external=1"
-                                $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
-                  ENVIRONMENT   "${_test_environment}"
+ecbuild_add_test( TARGET          test_multio_replay_nemo_capi_initdefault_empi
+                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
+                  TEST_REQUIRES   multio_replay_get_test_data
+                  ARGS            "$<TARGET_FILE:multio-replay-nemo-capi> --init-mpi-external=1"
+                                  $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
+                  ENVIRONMENT     "${_test_environment}"
+                  TEST_PROPERTIES RESOURCE_LOCK mpi
 )
 
-ecbuild_add_test( TARGET        test_multio_replay_nemo_capi_initdefault_impi1
-                  COMMAND       ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
-                  TEST_REQUIRES multio_replay_get_test_data
-                  ARGS          $<TARGET_FILE:multio-replay-nemo-capi>
-                                $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
-                  ENVIRONMENT   "${_test_environment}"
+ecbuild_add_test( TARGET          test_multio_replay_nemo_capi_initdefault_impi1
+                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
+                  TEST_REQUIRES   multio_replay_get_test_data
+                  ARGS            $<TARGET_FILE:multio-replay-nemo-capi>
+                                  $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
+                  ENVIRONMENT     "${_test_environment}"
+                  TEST_PROPERTIES RESOURCE_LOCK mpi
 )
 
-ecbuild_add_test( TARGET        test_multio_replay_nemo_capi_initdefault_impi2
-                  COMMAND       ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
-                  TEST_REQUIRES multio_replay_get_test_data
-                  ARGS          $<TARGET_FILE:multio-replay-nemo-capi>
-                                $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
-                  ENVIRONMENT   "${_test_environment}"
-                                "MULTIO_SERVER_CONFIG_7FILE=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server-mpi-default-splitting.yaml"
+ecbuild_add_test( TARGET          test_multio_replay_nemo_capi_initdefault_impi2
+                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
+                  TEST_REQUIRES   multio_replay_get_test_data
+                  ARGS            $<TARGET_FILE:multio-replay-nemo-capi>
+                                  $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
+                  ENVIRONMENT     "${_test_environment}"
+                                  "MULTIO_SERVER_CONFIG_7FILE=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server-mpi-default-splitting.yaml"
+                  TEST_PROPERTIES RESOURCE_LOCK mpi
 )
 
-ecbuild_add_test( TARGET        test_multio_replay_nemo_capi_initdefault_impi3
-                  COMMAND       ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
-                  TEST_REQUIRES multio_replay_get_test_data
-                  ARGS          "$<TARGET_FILE:multio-replay-nemo-capi> --mpi-group=custom"
-                                $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
-                  ENVIRONMENT   "${_test_environment}"
-                                "MULTIO_SERVER_CONFIG_FILE=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server-mpi-custom-splitting.yaml"
+ecbuild_add_test( TARGET          test_multio_replay_nemo_capi_initdefault_impi3
+                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
+                  TEST_REQUIRES   multio_replay_get_test_data
+                  ARGS            "$<TARGET_FILE:multio-replay-nemo-capi> --mpi-group=custom"
+                                  $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
+                  ENVIRONMENT     "${_test_environment}"
+                                  "MULTIO_SERVER_CONFIG_FILE=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server-mpi-custom-splitting.yaml"
+                  TEST_PROPERTIES RESOURCE_LOCK mpi
 )
 
-ecbuild_add_test( TARGET        test_multio_replay_nemo_capi_initdefault_passdown_mpi
-                  COMMAND       ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
-                  TEST_REQUIRES multio_replay_get_test_data
-                  ARGS          "$<TARGET_FILE:multio-replay-nemo-capi> --pass-down-mpi-comm=1"
-                                $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
-                  ENVIRONMENT   "${_test_environment}"
+ecbuild_add_test( TARGET          test_multio_replay_nemo_capi_initdefault_passdown_mpi
+                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
+                  TEST_REQUIRES   multio_replay_get_test_data
+                  ARGS            "$<TARGET_FILE:multio-replay-nemo-capi> --pass-down-mpi-comm=1"
+                                  $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
+                  ENVIRONMENT     "${_test_environment}"
+                  TEST_PROPERTIES RESOURCE_LOCK mpi
 )
 
-ecbuild_add_test( TARGET        test_multio_replay_nemo_fapi
-                  CONDITION     HAVE_FORTRAN
-                  COMMAND       ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
-                  TEST_REQUIRES multio_replay_get_test_data
-                  ARGS          $<TARGET_FILE:multio-replay-nemo-fapi>
-                                $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
-                  ENVIRONMENT   "${_test_environment}"
+ecbuild_add_test( TARGET          test_multio_replay_nemo_fapi
+                  CONDITION       HAVE_FORTRAN
+                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
+                  TEST_REQUIRES   multio_replay_get_test_data
+                  ARGS            $<TARGET_FILE:multio-replay-nemo-fapi>
+                                  $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
+                  ENVIRONMENT     "${_test_environment}"
+                  TEST_PROPERTIES RESOURCE_LOCK mpi
 )
 
-ecbuild_add_test( TARGET        test_multio_replay_nemo_capi_masked
-                  COMMAND       ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
-                  TEST_REQUIRES multio_replay_get_test_data
-                  ARGS          "$<TARGET_FILE:multio-replay-nemo-capi> --send-masks=1"
-                                $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
-                  ENVIRONMENT   "${_test_environment}"
-                                "MULTIO_SERVER_CONFIG_FILE=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server-masked.yaml"
+ecbuild_add_test( TARGET          test_multio_replay_nemo_capi_masked
+                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
+                  TEST_REQUIRES   multio_replay_get_test_data
+                  ARGS            "$<TARGET_FILE:multio-replay-nemo-capi> --send-masks=1"
+                                  $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
+                  ENVIRONMENT     "${_test_environment}"
+                                  "MULTIO_SERVER_CONFIG_FILE=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server-masked.yaml"
+                  TEST_PROPERTIES RESOURCE_LOCK mpi
 )
 
-ecbuild_add_test( TARGET        test_multio_replay_nemo_capi_partial_agg
-                  COMMAND       ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
-                  TEST_REQUIRES multio_replay_get_test_data
-                  ARGS          $<TARGET_FILE:multio-replay-nemo-capi-partial-agg>
-                                $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
-                  ENVIRONMENT   "${_test_environment}"
-                                "MULTIO_SERVER_CONFIG_FILE=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server-test-partial-agg.yaml"
+ecbuild_add_test( TARGET          test_multio_replay_nemo_capi_partial_agg
+                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/replay-nemo.sh
+                  TEST_REQUIRES   multio_replay_get_test_data
+                  ARGS            $<TARGET_FILE:multio-replay-nemo-capi-partial-agg>
+                                  $<TARGET_FILE:multio-probe> ${MPIEXEC_EXECUTABLE} ${MPI_ARGS}
+                  ENVIRONMENT     "${_test_environment}"
+                                  "MULTIO_SERVER_CONFIG_FILE=${CMAKE_CURRENT_SOURCE_DIR}/config/multio-server-test-partial-agg.yaml"
+                  TEST_PROPERTIES RESOURCE_LOCK mpi
 )
 
 endif(eckit_HAVE_MPI)

--- a/tests/multio/action/interpolate-healpix-nested/CMakeLists.txt
+++ b/tests/multio/action/interpolate-healpix-nested/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach (_n
 
     ecbuild_add_test(
         TARGET        ${PREFIX}_original
-        TEST_REQUIRES ${DATA_PREFIX}_get_data_interpolate ${DATA_PREFIX}_get_data_healpix_ring2nest
+        TEST_REQUIRES ${DATA_PREFIX}_get_data_interpolate ${DATA_PREFIX}_get_data_healpix_ring2nest ${DATA_PREFIX}_get_data_interpolate_healpix
         COMMAND       multio-feed
         ARGS          ${CMAKE_CURRENT_BINARY_DIR}/MARS_reduced_gg.grib --decode --plans=${CMAKE_CURRENT_SOURCE_DIR}/reduced_gg_to_HEALPix_${_n}_nested_original.yaml
     )
@@ -93,7 +93,7 @@ ecbuild_get_test_multidata(
 
 ecbuild_add_test(
     TARGET        ${PREFIX}_original
-    TEST_REQUIRES ${DATA_PREFIX}_get_data_fesom ${PREFIX}_fesom_csv_ring2mat_ring
+    TEST_REQUIRES ${DATA_PREFIX}_get_data_fesom ${PREFIX}_fesom_csv_ring2mat_ring ${DATA_PREFIX}_get_data_interpolate_healpix
     COMMAND       multio-feed
     ARGS          ${CMAKE_CURRENT_BINARY_DIR}/fesom_CORE2_ngrid_feed_o2d.grib --decode --plans=${CMAKE_CURRENT_SOURCE_DIR}/fesom_CORE2_ngrid_to_HEALPix_128_nested_original.yaml
 )
@@ -107,7 +107,7 @@ ecbuild_add_test(
 
 ecbuild_add_test(
     TARGET        ${PREFIX}_compare
-    TEST_REQUIRES ${PREFIX}_original;${PREFIX}_direct
+    TEST_REQUIRES ${PREFIX}_original ${PREFIX}_direct
     COMMAND       grib_compare
     ARGS          MultIO_fesom_CORE2_ngrid_to_HEALPix_128_nested_original.grib MultIO_fesom_CORE2_ngrid_to_HEALPix_128_nested_direct.grib
 )


### PR DESCRIPTION
This will make every test pass if you run it in isolation from a clean build and should make parallel tests pass from the first try.

You can now run (in a bundle): `( cd source/multio; ctest -j32 )`
Or to be safe I recommend: `( cd source/multio; ctest -j32 || ctest --rerun-failed )`