### PR TITLE
MUL-233: Fix operations using initial values from the wrong message

### DIFF
--- a/src/multio/action/statistics-mtg2/operations/DeAccumulate.h
+++ b/src/multio/action/statistics-mtg2/operations/DeAccumulate.h
@@ -28,6 +28,7 @@ public:
         LOG_DEBUG_LIB(LibMultio) << logHeader_ << ".compute().count=" << win_.count() << std::endl;
         auto val = static_cast<T*>(buf.data());
         cfg.bitmapPresent() ? computeWithMissing(val, cfg) : computeWithoutMissing(val, cfg);
+        std::copy(values_.begin(), values_.end(), initValues_.begin());
         return;
     }
 

--- a/src/multio/action/statistics-mtg2/operations/Difference.h
+++ b/src/multio/action/statistics-mtg2/operations/Difference.h
@@ -28,6 +28,7 @@ public:
         LOG_DEBUG_LIB(LibMultio) << logHeader_ << ".compute().count=" << win_.count() << std::endl;
         auto val = static_cast<T*>(buf.data());
         cfg.bitmapPresent() ? computeWithMissing(val, cfg) : computeWithoutMissing(val, cfg);
+        std::copy(values_.begin(), values_.end(), initValues_.begin());
         return;
     }
 

--- a/src/multio/action/statistics-mtg2/operations/FixedWindowFluxAverage.h
+++ b/src/multio/action/statistics-mtg2/operations/FixedWindowFluxAverage.h
@@ -28,6 +28,7 @@ public:
         LOG_DEBUG_LIB(LibMultio) << logHeader_ << ".compute().count=" << win_.count() << std::endl;
         auto val = static_cast<T*>(buf.data());
         cfg.bitmapPresent() ? computeWithMissing(val, cfg) : computeWithoutMissing(val, cfg);
+        std::copy(values_.begin(), values_.end(), initValues_.begin());
         return;
     }
 

--- a/src/multio/action/statistics-mtg2/operations/InverseDifference.h
+++ b/src/multio/action/statistics-mtg2/operations/InverseDifference.h
@@ -28,6 +28,7 @@ public:
         LOG_DEBUG_LIB(LibMultio) << logHeader_ << ".compute().count=" << win_.count() << std::endl;
         auto val = static_cast<T*>(buf.data());
         cfg.bitmapPresent() ? computeWithMissing(val, cfg) : computeWithoutMissing(val, cfg);
+        std::copy(values_.begin(), values_.end(), initValues_.begin());
         return;
     }
 

--- a/src/multio/action/statistics-mtg2/operations/OperationWithDeaccumulatedData.h
+++ b/src/multio/action/statistics-mtg2/operations/OperationWithDeaccumulatedData.h
@@ -36,9 +36,9 @@ public:
             std::transform(values_.begin(), values_.end(), values_.begin(), [](T v) { return static_cast<T>(0.0); });
         }
         else {
-            const T* val = static_cast<const T*>(data);
-            std::transform(initValues_.begin(), initValues_.end(), val, initValues_.begin(),
-                           [](const T& v1, const T& v2) { return static_cast<T>(v2); });
+            // const T* val = static_cast<const T*>(data);
+            // std::transform(initValues_.begin(), initValues_.end(), val, initValues_.begin(),
+            //                [](const T& v1, const T& v2) { return static_cast<T>(v2); });
             std::transform(values_.begin(), values_.end(), values_.begin(), [](T v) { return static_cast<T>(0.0); });
         }
         return;

--- a/tests/multio/action/statistics-mtg2/operations/CMakeLists.txt
+++ b/tests/multio/action/statistics-mtg2/operations/CMakeLists.txt
@@ -23,7 +23,6 @@ ecbuild_add_test(
 )
 
 ecbuild_add_test(
-    ENABLED FALSE
     TARGET ${PREFIX}_difference
     SOURCES Difference.cc
     NO_AS_NEEDED
@@ -31,7 +30,6 @@ ecbuild_add_test(
 )
 
 ecbuild_add_test(
-    ENABLED FALSE
     TARGET ${PREFIX}_inverse_difference
     SOURCES InverseDifference.cc
     NO_AS_NEEDED
@@ -46,7 +44,6 @@ ecbuild_add_test(
 )
 
 ecbuild_add_test(
-    ENABLED FALSE
     TARGET ${PREFIX}_deaccumulate
     SOURCES DeAccumulate.cc
     NO_AS_NEEDED
@@ -61,7 +58,6 @@ ecbuild_add_test(
 )
 
 ecbuild_add_test(
-    ENABLED FALSE
     TARGET ${PREFIX}_fixed_window_flux_average
     SOURCES FixedWindowFluxAverage.cc
     NO_AS_NEEDED


### PR DESCRIPTION
Some operations base their calculations on the last message in the previous (`initValues_`) and current window (`values_`). This was broken with the changes for removing the step-frequency.

See also: [MUL-233](https://jira.ecmwf.int/browse/MUL-233)