### PR TITLE
Cleanup statistics-mtg2 configuration

### DIFF
--- a/src/multio/action/statistics-mtg2/Statistics.cc
+++ b/src/multio/action/statistics-mtg2/Statistics.cc
@@ -115,10 +115,6 @@ std::string Statistics::generateRestartNameFromFlush(const message::Message& msg
 void Statistics::CreateMainRestartDirectory(const std::string& restartFolderName, bool is_master) {
 
     // Create the main restart directory
-    // TODO: if statistics are client side opt_.clientSideStatistics() then
-    // the restart directory should be created with appended the mpi-rank of
-    // processor that is creating the directory and all following login should
-    // be skipped since every processor will create its own directory.
     IOmanager_->setDateTime(restartFolderName);
 
     // Only master create the directory

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -138,44 +138,27 @@ void StatisticsConfiguration::readLevel(const message::Metadata& md, const Stati
 };
 
 void StatisticsConfiguration::readStartTime(const message::Metadata& md, const StatisticsOptions& opt) {
-    std::optional<std::int64_t> timeVal;
-    if (opt.useDateTime() && (timeVal = md.getOpt<std::int64_t>(dm::legacy::Time))) {
-        time_ = *timeVal;
-    }
-    else if (!opt.useDateTime() && (timeVal = md.getOpt<std::int64_t>(dm::legacy::StartTime))) {
-        time_ = *timeVal;
-    }
-    else {
-        throw eckit::SeriousBug{"Unable to find start time", Here()};
-    }
-    return;
+    // NOTE: Currently no support for messages without step (from analysis)!
+    ASSERT(md.getOpt<std::int64_t>(dm::legacy::Step).has_value());
+    const auto timeVal = md.getOpt<std::int64_t>(dm::legacy::Time);
+    ASSERT(timeVal.has_value());
+    time_ = *timeVal;
 };
 
 void StatisticsConfiguration::readStartDate(const message::Metadata& md, const StatisticsOptions& opt) {
-    std::optional<std::int64_t> dateVal;
-    if (opt.useDateTime() && (dateVal = md.getOpt<std::int64_t>(dm::legacy::Date))) {
-        date_ = *dateVal;
-    }
-    else if (!opt.useDateTime() && (dateVal = md.getOpt<std::int64_t>(dm::legacy::StartDate))) {
-        date_ = *dateVal;
-    }
-    else {
-        throw eckit::SeriousBug{"Unable to find start date", Here()};
-    }
-    return;
+    // NOTE: Currently no support for messages without step (from analysis)!
+    ASSERT(md.getOpt<std::int64_t>(dm::legacy::Step).has_value());
+    const auto dateVal = md.getOpt<std::int64_t>(dm::legacy::Date);
+    ASSERT(dateVal.has_value());
+    date_ = *dateVal;
 };
 
 
 void StatisticsConfiguration::readStep(const message::Metadata& md, const StatisticsOptions& opt) {
-    if (auto step = md.getOpt<std::int64_t>(dm::legacy::EndStep); step) {
-        step_ = *step;
-        return;
-    }
-    if (auto step = md.getOpt<std::int64_t>(dm::legacy::Step); step) {
-        step_ = *step;
-        return;
-    }
-    throw eckit::SeriousBug{"Step metadata not present", Here()};
+    // NOTE: Currently no support for messages without step (from analysis)!
+    const auto stepVal = md.getOpt<std::int64_t>(dm::legacy::Step);
+    ASSERT(stepVal.has_value());
+    step_ = *stepVal;
 };
 
 void StatisticsConfiguration::readTimeStep(const message::Metadata& md, const StatisticsOptions& opt) {

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
@@ -10,7 +10,6 @@ StatisticsOptions::StatisticsOptions(const config::ComponentConfiguration& compC
     readRestart_{false},
     writeRestart_{false},
     debugRestart_{false},
-    useDateTime_{false},
     clientSideStatistics_{false},
     restartTime_{"latest"},  // 00000000-000000
     restartPath_{"."},
@@ -32,7 +31,6 @@ StatisticsOptions::StatisticsOptions(const config::ComponentConfiguration& compC
     // Read the options
     if (compConf.parsedConfig().has("options")) {
         const auto& options = compConf.parsedConfig().getSubConfiguration("options");
-        parseUseDateTime(options);
         parseTimeStep(options);
         parseInitialConditionPresent(options);
         parseWriteRestart(options);
@@ -59,12 +57,6 @@ StatisticsOptions::StatisticsOptions(const config::ComponentConfiguration& compC
     return;
 };
 
-
-void StatisticsOptions::parseUseDateTime(const eckit::LocalConfiguration& cfg) {
-    // Distance in steps between two messages
-    useDateTime_ = cfg.getLong("use-current-time", false);
-    return;
-};
 
 void StatisticsOptions::parseTimeStep(const eckit::LocalConfiguration& cfg) {
     // How many seconds in a timestep

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
@@ -10,7 +10,6 @@ StatisticsOptions::StatisticsOptions(const config::ComponentConfiguration& compC
     readRestart_{false},
     writeRestart_{false},
     debugRestart_{false},
-    clientSideStatistics_{false},
     restartTime_{"latest"},  // 00000000-000000
     restartPath_{"."},
     restartPrefix_{"StatisticsRestartFile"},
@@ -35,7 +34,6 @@ StatisticsOptions::StatisticsOptions(const config::ComponentConfiguration& compC
         parseInitialConditionPresent(options);
         parseWriteRestart(options);
         parseDebugRestart(options);
-        parseClientSideStatistics(options);
         parseReadRestart(options);
         parseRestartPath(compConf, options);
         parseRestartPrefix(compConf, options);
@@ -99,22 +97,6 @@ void StatisticsOptions::parseDebugRestart(const eckit::LocalConfiguration& cfg) 
     else {
         usage();
         throw eckit::SeriousBug{"Unable to read restart", Here()};
-    }
-    return;
-};
-
-
-void StatisticsOptions::parseClientSideStatistics(const eckit::LocalConfiguration& cfg) {
-    // Used to determine if the simulation need to save/load
-    // restart files.
-    std::optional<bool> r;
-    r = util::parseBool(cfg, "is-client-side", false);
-    if (r) {
-        clientSideStatistics_ = *r;
-    }
-    else {
-        usage();
-        throw eckit::SeriousBug{"Unable to read client-side", Here()};
     }
     return;
 };
@@ -288,10 +270,6 @@ bool StatisticsOptions::writeRestart() const {
 
 bool StatisticsOptions::debugRestart() const {
     return debugRestart_;
-};
-
-bool StatisticsOptions::clientSideStatistics() const {
-    return clientSideStatistics_;
 };
 
 

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
@@ -21,7 +21,6 @@ private:
     bool readRestart_;
     bool writeRestart_;
     bool debugRestart_;
-    bool clientSideStatistics_;
     std::string restartTime_;
 
     std::string restartPath_;
@@ -38,12 +37,10 @@ private:
     std::vector<std::pair<std::string, std::string>> setMetadata_;
 
 private:
-    void parseCheckMissingValues(const eckit::LocalConfiguration& cfg);
     void parseTimeStep(const eckit::LocalConfiguration& cfg);
     void parseInitialConditionPresent(const eckit::LocalConfiguration& cfg);
     void parseWriteRestart(const eckit::LocalConfiguration& cfg);
     void parseDebugRestart(const eckit::LocalConfiguration& cfg);
-    void parseClientSideStatistics(const eckit::LocalConfiguration& cfg);
     void parseReadRestart(const eckit::LocalConfiguration& cfg);
     void parseRestartPath(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
     void parseRestartPrefix(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
@@ -67,17 +64,12 @@ public:
     const std::string& logPrefix() const;
     const std::string& windowType() const;
 
-    // Handle missing value
-    const std::string& bitmapPresentKey() const;
-    const std::string& missingValueKey() const;
-
     // Default values
     long timeStep() const;
     bool solver_send_initial_condition() const;
     bool readRestart() const;
     bool writeRestart() const;
     bool debugRestart() const;
-    bool clientSideStatistics() const;
 
     const std::string& restartTime() const;
     const std::string& restartPath() const;

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
@@ -21,7 +21,6 @@ private:
     bool readRestart_;
     bool writeRestart_;
     bool debugRestart_;
-    bool useDateTime_;
     bool clientSideStatistics_;
     std::string restartTime_;
 
@@ -39,7 +38,6 @@ private:
     std::vector<std::pair<std::string, std::string>> setMetadata_;
 
 private:
-    void parseUseDateTime(const eckit::LocalConfiguration& cfg);
     void parseCheckMissingValues(const eckit::LocalConfiguration& cfg);
     void parseTimeStep(const eckit::LocalConfiguration& cfg);
     void parseInitialConditionPresent(const eckit::LocalConfiguration& cfg);
@@ -68,7 +66,6 @@ public:
 
     const std::string& logPrefix() const;
     const std::string& windowType() const;
-    bool useDateTime() const { return useDateTime_; };
 
     // Handle missing value
     const std::string& bitmapPresentKey() const;

--- a/tests/multio/action/statistics-mtg2/CheckpointAndRestart.cc
+++ b/tests/multio/action/statistics-mtg2/CheckpointAndRestart.cc
@@ -59,8 +59,8 @@ CASE("simple checkpoint and restart") {
             Metadata md{{{"param", 130},
                          {"levtype", "sfc"},
                          {"grid", "custom"},
-                         {"startDate", 20250430},
-                         {"startTime", 0000},
+                         {"date", 20250430},
+                         {"time", 0000},
                          {"step", step},
                          {"misc-precision", "double"}}};
             eckit::Buffer pl{&val, sizeof(double)};
@@ -122,8 +122,8 @@ CASE("simple checkpoint and restart") {
             Metadata md{{{"param", 130},
                          {"levtype", "sfc"},
                          {"grid", "custom"},
-                         {"startDate", 20250430},
-                         {"startTime", 0000},
+                         {"date", 20250430},
+                         {"time", 0000},
                          {"step", step},
                          {"misc-precision", "double"}}};
             eckit::Buffer pl{&val, sizeof(double)};

--- a/tests/multio/action/statistics-mtg2/MultipleLoops.cc
+++ b/tests/multio/action/statistics-mtg2/MultipleLoops.cc
@@ -43,8 +43,8 @@ CASE("Monthly average of daily high temperature") {
         auto md = Metadata({{"param", 167},
                             {"levtype", "sfc"},
                             {"grid", "none"},
-                            {"startDate", 19961001},
-                            {"startTime", 0000},
+                            {"date", 19961001},
+                            {"time", 0000},
                             {"step", step},
                             {"misc-precision", "double"}});
 
@@ -107,8 +107,8 @@ CASE("Montly average of daily high of average 3 hourly temperature") {
         auto md = Metadata({{"param", 167},
                             {"levtype", "sfc"},
                             {"grid", "none"},
-                            {"startDate", 19961001},
-                            {"startTime", 0000},
+                            {"date", 19961001},
+                            {"time", 0000},
                             {"step", step},
                             {"misc-precision", "double"}});
 

--- a/tests/multio/action/statistics-mtg2/ParamMapping.cc
+++ b/tests/multio/action/statistics-mtg2/ParamMapping.cc
@@ -96,8 +96,8 @@ std::int64_t testParameterMapping(std::int64_t param, std::string op) {
             {"param", param},
             {"levtype", "none"},
             {"grid", "none"},
-            {"startDate", 20200721},
-            {"startTime", 0000},
+            {"date", 20200721},
+            {"time", 0000},
             {"step", step},
             {"misc-precision", "double"}
         });

--- a/tests/multio/action/statistics-mtg2/SingleFieldSingleFlush.cc
+++ b/tests/multio/action/statistics-mtg2/SingleFieldSingleFlush.cc
@@ -55,8 +55,8 @@ void testFieldAndFlush(std::string flushKind, int64_t steps=1) {
             {"param", 130},
             {"levtype", "sfc"},
             {"grid", "custom"},
-            {"startDate", 20250425},
-            {"startTime", 0000},
+            {"date", 20250425},
+            {"time", 0000},
             {"step", step},
             {"misc-precision", "double"}
         }};

--- a/tests/multio/action/statistics-mtg2/operations/Operation.h
+++ b/tests/multio/action/statistics-mtg2/operations/Operation.h
@@ -154,8 +154,8 @@ private:
             {"param", 130},
             {"levtype", "sfc"},
             {"grid", "custom"},
-            {"startDate", 20200721},
-            {"startTime", 0000},
+            {"date", 20200721},
+            {"time", 0000},
             {"step", step},
             {"misc-precision", std::is_same_v<ElemType, float> ? "single" : "double"}
         });


### PR DESCRIPTION
- Always assume `step` is set (asserted), and treat `date` and `time` as the start date/time.
  - This makes the `use-current-time` configuration option obsolete
- Remove unused methods. These are not implemented or never called:
  - `bitmapPresentKey()`
  - `missingValueKey()`
  - `clientSideStatistics()`

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-159
<!-- PREVIEW-URL_END -->