### PR TITLE
Python wheel wrapper -- strip due to size

### DIFF
--- a/python/multiolib/post-compile.sh
+++ b/python/multiolib/post-compile.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# NOTE we need to strip here because vanilla multio is for some reason huge
+# We don't strip in general since that has caused some linker problem downstream
+# But eg in Atlas we also strip due to size reason and so far no issues
+
+if [ "$(uname)" != "Darwin" ] ; then
+    strip --strip-unneeded /tmp/multio/target/multio/lib64/lib*.so
+else 
+    strip -x /tmp/multio/target/multio/lib/lib*.dylib
+fi


### PR DESCRIPTION
A recent run of the multiolib wheel publish to pypi failed for size reasons -- https://github.com/ecmwf/python-develop-bundle/actions/runs/18089729701/job/51472698561

We add stripping, like we did for atlas some time ago

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-161
<!-- PREVIEW-URL_END -->