### PR TITLE
Adjust the test data path for Nexus migration

### DIFF
--- a/tests/across/CMakeLists.txt
+++ b/tests/across/CMakeLists.txt
@@ -14,7 +14,7 @@ list( APPEND _across_test_data
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_get_data
-    DIRNAME  multio/tests/across
+    DIRNAME  multio/test-data/tests/across
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES ${_across_test_data}
 )

--- a/tests/ecom/extremesDT/CMakeLists.txt
+++ b/tests/ecom/extremesDT/CMakeLists.txt
@@ -4,7 +4,7 @@ set(PREFIX ecom_extremesDT)
 ecbuild_get_test_multidata(
   EXTRACT
   TARGET ${PREFIX}_get_test_data
-  DIRNAME ecom/extremesDT/001
+  DIRNAME ecom/test-data/extremesDT/001
   DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
   NAMES
     "reference.tar.bz"
@@ -13,7 +13,7 @@ ecbuild_get_test_multidata(
 
 ecbuild_get_test_multidata(
   TARGET ${PREFIX}_get_test_cfg
-  DIRNAME ecom/extremesDT/001
+  DIRNAME ecom/test-data/extremesDT/001
   DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
   NAMES
     "output-manager-config.yaml"

--- a/tests/multio/CMakeLists.txt
+++ b/tests/multio/CMakeLists.txt
@@ -128,7 +128,7 @@ list( APPEND _test_data
 )
 
 ecbuild_get_test_multidata( TARGET multio_get_test_data
-                            DIRNAME fdb5/tests/fdb
+                            DIRNAME fdb5/test-data/tests/fdb
                             NAMES ${_test_data} )
 
 ecbuild_add_test( TARGET test_multio_ifs_plans
@@ -186,7 +186,7 @@ list( APPEND _hammer_test_data
 )
 
 ecbuild_get_test_multidata( TARGET multio_hammer_get_test_data
-                            DIRNAME multio/tests/server
+                            DIRNAME multio/test-data/tests/server
                             NAMES ${_hammer_test_data} )
 
 ecbuild_add_test( ENABLED       OFF
@@ -211,7 +211,7 @@ list( APPEND _nemo_test_data
 )
 
 ecbuild_get_test_multidata( EXTRACT TARGET multio_replay_get_test_data
-                            DIRNAME multio/tests/server
+                            DIRNAME multio/test-data/tests/server
                             NAMES ${_nemo_test_data}
 )
 

--- a/tests/multio/action/encode/ifs/CMakeLists.txt
+++ b/tests/multio/action/encode/ifs/CMakeLists.txt
@@ -13,7 +13,7 @@ file(MAKE_DIRECTORY ${TEST_IFS_TEMPLATES_PATH})
 ecbuild_get_test_multidata(
     EXTRACT
     TARGET multio_action_ifs_get_test_data
-    DIRNAME multio/tests/actions
+    DIRNAME multio/test-data/tests/actions
     DIRLOCAL ${TEST_IFS_TEMPLATES_PATH}
     NAMES ${_action_ifs_test_data} )
 

--- a/tests/multio/action/interpolate-fesom/CMakeLists.txt
+++ b/tests/multio/action/interpolate-fesom/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/fesom_CORE2_ngrid_mappings.yaml ${CM
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_get_data
-    DIRNAME  multio/tests/actions/interpolate-fesom
+    DIRNAME  multio/test-data/tests/actions/interpolate-fesom
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES
         "fesom_CORE2_mesh.atlas"
@@ -35,7 +35,7 @@ ecbuild_get_test_multidata(
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_get_cache
-    DIRNAME  multio/tests/actions/interpolate-fesom/cache
+    DIRNAME  multio/test-data/tests/actions/interpolate-fesom/cache
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}/cache
     NAMES
         "fesom_CORE2_ngrid_to_HEALPix_000032_double_ring_00000000.atlas"

--- a/tests/multio/action/interpolate-healpix-nested/CMakeLists.txt
+++ b/tests/multio/action/interpolate-healpix-nested/CMakeLists.txt
@@ -4,14 +4,14 @@ set(DATA_PREFIX multio_tests_action_interpolate_reduced_gg_to_HEALPix_nested)
 
 ecbuild_get_test_multidata(
     TARGET   ${DATA_PREFIX}_get_data_interpolate
-    DIRNAME  multio/tests/actions/interpolate
+    DIRNAME  multio/test-data/tests/actions/interpolate
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES    "MARS_reduced_gg.grib"
 )
 
 ecbuild_get_test_multidata(
     TARGET   ${DATA_PREFIX}_get_data_healpix_ring2nest
-    DIRNAME  multio/tests/actions/healpix_ring2nest
+    DIRNAME  multio/test-data/tests/actions/healpix_ring2nest
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES    "Reference_HEALPix_32_nested.grib"
              "Reference_HEALPix_1024_nested.grib"
@@ -19,7 +19,7 @@ ecbuild_get_test_multidata(
 
 ecbuild_get_test_multidata(
     TARGET   ${DATA_PREFIX}_get_data_interpolate_healpix
-    DIRNAME  multio/tests/actions/interpolate-healpix-nested
+    DIRNAME  multio/test-data/tests/actions/interpolate-healpix-nested
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES    "Reference_reduced_gg_to_HEALPix_32_nested.grib"
              "Reference_reduced_gg_to_HEALPix_1024_nested.grib"
@@ -84,7 +84,7 @@ ecbuild_add_test(
 
 ecbuild_get_test_multidata(
     TARGET   ${DATA_PREFIX}_get_data_fesom
-    DIRNAME  multio/tests/actions/interpolate-fesom
+    DIRNAME  multio/test-data/tests/actions/interpolate-fesom
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES
         "fesom_CORE2_ngrid_feed_o2d.grib"

--- a/tests/multio/action/interpolate/CMakeLists.txt
+++ b/tests/multio/action/interpolate/CMakeLists.txt
@@ -4,7 +4,7 @@ set(PREFIX multio_tests_action_interpolate)
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_get_data
-    DIRNAME  multio/tests/actions/interpolate
+    DIRNAME  multio/test-data/tests/actions/interpolate
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES
         "MARS_reduced_gg.grib"
@@ -96,7 +96,7 @@ if ( HAVE_HEALPIX_EXAMPLES )
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_get_HEALPix_data
-    DIRNAME  multio/tests/actions/interpolate
+    DIRNAME  multio/test-data/tests/actions/interpolate
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES
         "Reference_reduced_gg_to_HEALPix_32.grib"

--- a/tests/multio/action/renumber-healpix/CMakeLists.txt
+++ b/tests/multio/action/renumber-healpix/CMakeLists.txt
@@ -5,7 +5,7 @@ set(PREFIX multio_tests_action_healpix_ring2nest)
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_get_HEALPix_remapping_data
-    DIRNAME  multio/tests/actions/healpix_ring2nest
+    DIRNAME  multio/test-data/tests/actions/healpix_ring2nest
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES
         "Feed_HEALPix_32_ring.grib"

--- a/tests/multio/action/statistics/CMakeLists.txt
+++ b/tests/multio/action/statistics/CMakeLists.txt
@@ -51,7 +51,7 @@ endif( HAVE_MIR )
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_get_data
-    DIRNAME  multio/tests/actions/new-statistics
+    DIRNAME  multio/test-data/tests/actions/new-statistics
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES ${_statistics_test_data}
 )

--- a/tests/multio/action/statistics/moving-mask/CMakeLists.txt
+++ b/tests/multio/action/statistics/moving-mask/CMakeLists.txt
@@ -6,7 +6,7 @@ set(PREFIX multio_tests_action_statistics_moving_mask)
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_static_get_input_data
-    DIRNAME  multio/tests/actions/new-statistics
+    DIRNAME  multio/test-data/tests/actions/new-statistics
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES
         reduced_gg_pl_80_avg_grib2.tmpl
@@ -47,7 +47,7 @@ ecbuild_add_test(
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_get_input_data
-    DIRNAME  multio/tests/actions/statistics-moving-mask
+    DIRNAME  multio/test-data/tests/actions/statistics-moving-mask
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES
         Original_moving_mask.grib
@@ -81,7 +81,7 @@ foreach(_th 10d all any)
 
     ecbuild_get_test_multidata(
         TARGET   ${PREFIX}_${_op}_1m_${_th}_get_reference_data
-        DIRNAME  multio/tests/actions/statistics-moving-mask
+        DIRNAME  multio/test-data/tests/actions/statistics-moving-mask
         DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
         NAMES    Reference_${_op}_1m_${_th}.grib
     )

--- a/tests/multio/action/statistics/restart/CMakeLists.txt
+++ b/tests/multio/action/statistics/restart/CMakeLists.txt
@@ -23,7 +23,7 @@ list( APPEND _statistics_restart_test_data
 
 ecbuild_get_test_multidata(
     TARGET   ${PREFIX}_get_data
-    DIRNAME  multio/tests/actions/statistics-restart
+    DIRNAME  multio/test-data/tests/actions/statistics-restart
     DIRLOCAL ${CMAKE_CURRENT_BINARY_DIR}
     NAMES ${_statistics_restart_test_data}
 )


### PR DESCRIPTION
### Description

Adjust the test data path for Nexus migration. Instead of using https://get.ecmwf.int/repository/test-data/*project*/, the project will now access the data at https://sites.ecmwf.int/repository/*project*/test-data/.

This change also implies the use of the latest ecbuild, with the necessary adjustments to ecbuild_get_test_data/multidata functions.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-163
<!-- PREVIEW-URL_END -->