### PR TITLE
`statistics-mtg2` configuration/options cleanup

### DIFF
--- a/src/multio/action/statistics-mtg2/OperationWindow.cc
+++ b/src/multio/action/statistics-mtg2/OperationWindow.cc
@@ -59,8 +59,8 @@ eckit::DateTime yyyymmdd_hhmmss2DateTime(uint64_t yyyymmdd, uint64_t hhmmss) {
 
 OperationWindow make_window(const std::unique_ptr<PeriodUpdater>& periodUpdater, const StatisticsConfiguration& cfg) {
     eckit::DateTime epochPoint{cfg.epoch()};
-    eckit::DateTime startPoint{periodUpdater->computeWinStartTime(cfg.winStart())};
-    eckit::DateTime creationPoint{periodUpdater->computeWinCreationTime(cfg.winStart())};
+    eckit::DateTime startPoint{periodUpdater->computeWinStartTime(cfg.curr())};
+    eckit::DateTime creationPoint{periodUpdater->computeWinCreationTime(cfg.curr())};
     eckit::DateTime endPoint{periodUpdater->computeWinEndTime(startPoint)};
     long windowType = 0;
     if (cfg.options().windowType() == "forward-offset") {

--- a/src/multio/action/statistics-mtg2/Operations.cc
+++ b/src/multio/action/statistics-mtg2/Operations.cc
@@ -28,7 +28,7 @@ std::vector<std::unique_ptr<Operation>> make_operations(const std::vector<std::s
         std::vector<std::unique_ptr<Operation>> stats;
         for (const auto& op : opNames) {
             stats.push_back(make_operation<Precision>(op, msg.size(), IOmanager, win, cfg));
-            if (cfg.options().solver_send_initial_condition()) {
+            if (cfg.options().initialConditionPresent()) {
                 stats.back()->init(msg.payload().data(), msg.size(), msg, cfg);
             }
             else {

--- a/src/multio/action/statistics-mtg2/Statistics.cc
+++ b/src/multio/action/statistics-mtg2/Statistics.cc
@@ -387,7 +387,7 @@ void Statistics::executeImpl(message::Message msg) {
     // This can happen when the solver is sending the initial condition
     // and and the same point is already present in the restart
     auto& ts = *(stat->second);
-    if (cfg.curr() == ts.cwin().currPoint() && opt_.solver_send_initial_condition()) {
+    if (cfg.curr() == ts.cwin().currPoint() && opt_.initialConditionPresent()) {
         return;
     }
 

--- a/src/multio/action/statistics-mtg2/Statistics.cc
+++ b/src/multio/action/statistics-mtg2/Statistics.cc
@@ -37,7 +37,7 @@ Statistics::Statistics(const ComponentConfiguration& compConf) :
     ChainedAction{compConf},
     needRestart_{false},
     lastDateTime_{""},
-    opt_{compConf},
+    opt_{compConf.parsedConfig().getSubConfiguration("options")},
     operations_{compConf.parsedConfig().getStringVector("operations")},
     outputFrequency_{compConf.parsedConfig().getString("output-frequency")},
     paramMapping_{StatisticsParamMapping::makeStatisticsParamMapping()},

--- a/src/multio/action/statistics-mtg2/SynopticCollection.cc
+++ b/src/multio/action/statistics-mtg2/SynopticCollection.cc
@@ -117,7 +117,7 @@ SynopticCollection::SynopticCollection(const std::string& operation, const messa
     filter_{op_[0] == op_[1] ? make_filter(op_[1], cfg) : make_filter(op_[1], filterConf.at(op_[0]), cfg)}  //,
 //    statistics_{make_operations(op_[2], msg, filter_->size(), IOmanager, win, cfg)}
 {
-    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.logPrefix() << " *** SynopticCollection standard constructor "
+    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.options().logPrefix() << " *** SynopticCollection standard constructor "
                                        << std::endl;
 };
 
@@ -132,7 +132,7 @@ SynopticCollection::SynopticCollection(const std::string& operation, const std::
     filter_{op_[0] == op_[1] ? make_filter(op_[1], cfg) : make_filter(op_[1], filterConf.at(op_[0]), cfg)}  //,
 //    statistics_{load_operations(op_[2], precision, filter_->size(), IOmanager, win, cfg)}
 {
-    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.logPrefix() << " *** SynopticCollection load constructor " << std::endl;
+    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.options().logPrefix() << " *** SynopticCollection load constructor " << std::endl;
 };
 
 
@@ -144,7 +144,7 @@ size_t SynopticCollection::size() const {
 
 
 void SynopticCollection::resetWindow(const message::Message& msg, const StatisticsConfiguration& cfg) {
-    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.logPrefix() << " *** SynopticCollection::updateWindow " << std::endl;
+    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.options().logPrefix() << " *** SynopticCollection::updateWindow " << std::endl;
     for (auto& stat : statistics_) {
         // TODO: Just set to zero all the data of the window
         // stat.resetWindow();
@@ -161,7 +161,7 @@ void SynopticCollection::resetWindow(const message::Message& msg, const Statisti
 
 
 void SynopticCollection::updateData(const message::Message& msg, const StatisticsConfiguration& cfg) {
-    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.logPrefix() << " *** SynopticCollection::updateData " << std::endl;
+    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.options().logPrefix() << " *** SynopticCollection::updateData " << std::endl;
     size_t key;
     if (filter_->match(msg, cfg, key)) {
         // TODO: add profiling code
@@ -181,7 +181,7 @@ void SynopticCollection::fillMetadata(size_t idx, message::Metadata& metadata) c
 
 
 void SynopticCollection::dump(std::shared_ptr<StatisticsIO>& IOmanager, const StatisticsConfiguration& cfg) const {
-    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.logPrefix() << " *** SynopticCollection::dump " << std::endl;
+    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.options().logPrefix() << " *** SynopticCollection::dump " << std::endl;
     std::ostringstream os;
     size_t cnt = 0;
     for (auto& stat : statistics_) {

--- a/src/multio/action/statistics-mtg2/TemporalStatistics.cc
+++ b/src/multio/action/statistics-mtg2/TemporalStatistics.cc
@@ -71,7 +71,7 @@ void TemporalStatistics::dump(std::shared_ptr<StatisticsIO>& IOmanager, const St
 }
 
 void TemporalStatistics::updateData(message::Message& msg, const StatisticsConfiguration& cfg) {
-    LOG_DEBUG_LIB(multio::LibMultio) << cfg.logPrefix() << " *** Update Data" << std::endl;
+    LOG_DEBUG_LIB(multio::LibMultio) << cfg.options().logPrefix() << " *** Update Data" << std::endl;
     window_.updateData(currentDateTime(msg, cfg));
     for (auto& stat : statistics_) {
         // Truncation is always present when we are dealing with Spherical Harmonics
@@ -86,7 +86,7 @@ void TemporalStatistics::updateData(message::Message& msg, const StatisticsConfi
 }
 
 void TemporalStatistics::updateWindow(const message::Message& msg, const StatisticsConfiguration& cfg) {
-    LOG_DEBUG_LIB(multio::LibMultio) << cfg.logPrefix() << " *** Update Window " << std::endl;
+    LOG_DEBUG_LIB(multio::LibMultio) << cfg.options().logPrefix() << " *** Update Window " << std::endl;
     window_.updateWindow(window_.endPoint(), periodUpdater_->updateWinEndTime(window_.endPoint()));
     for (auto& stat : statistics_) {
         stat->updateWindow(msg.payload().data(), msg.size(), msg, cfg);
@@ -96,7 +96,7 @@ void TemporalStatistics::updateWindow(const message::Message& msg, const Statist
 }
 
 bool TemporalStatistics::isOutsideWindow(message::Message& msg, const StatisticsConfiguration& cfg) {
-    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.logPrefix() << " *** Check outside Window " << std::endl;
+    LOG_DEBUG_LIB(::multio::LibMultio) << cfg.options().logPrefix() << " *** Check outside Window " << std::endl;
     return !window_.isWithin(currentDateTime(msg, cfg));
 }
 

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -124,12 +124,9 @@ StatisticsConfiguration::StatisticsConfiguration(const message::Metadata& md, co
     gridType_{readGridType(md)},
     precision_{readPrecision(md)},
     missingValue_{readMissingValue(md)},
-    key_{generateKey(src)} {
-    // Associate local procedure pointers
-    computeEpoch_ = std::bind(&StatisticsConfiguration::computeEpoch, this);
-    computeCurr_ = std::bind(&StatisticsConfiguration::computeCurr, this);
-    computeWinStart_ = std::bind(&StatisticsConfiguration::computeWinStart, this);
-}
+    key_{generateKey(src)},
+    epoch_{computeEpoch()},
+    curr_{computeCurr()} {}
 
 StatisticsConfiguration::StatisticsConfiguration(const message::Message& msg, const StatisticsOptions& opt) :
     StatisticsConfiguration(msg.metadata(), msg.source(), opt) {};
@@ -142,57 +139,16 @@ std::string StatisticsConfiguration::generateKey(const message::Peer& src) const
     return os.str();
 }
 
-
-eckit::DateTime StatisticsConfiguration::epoch() const {
-    epoch_ = computeEpoch_();
-    return epoch_;
-}
-
-eckit::DateTime StatisticsConfiguration::curr() const {
-    curr_ = computeCurr_();
-    return curr_;
-}
-
-eckit::DateTime StatisticsConfiguration::winStart() const {
-    winStart_ = computeWinStart_();
-    return winStart_;
-}
-
-
 eckit::DateTime StatisticsConfiguration::computeEpoch() const {
-    eckit::Date startDate{date_};
-    auto hour = time_ / 10000;
-    auto minute = (time_ % 10000) / 100;
-    epoch_ = eckit::DateTime{startDate, eckit::Time{hour, minute, 0}};
-    computeEpoch_ = std::bind(&StatisticsConfiguration::getEpoch, this);
-    return epoch_;
-};
-
-eckit::DateTime StatisticsConfiguration::getEpoch() const {
-    return epoch_;
+    eckit::Date date{date_};
+    const auto hour = time_ / 10000;
+    const auto minute = (time_ % 10000) / 100;
+    return eckit::DateTime{date, eckit::Time{hour, minute, 0}};
 }
 
 
 eckit::DateTime StatisticsConfiguration::computeCurr() const {
-    curr_ = epoch() + static_cast<eckit::Second>(std::max((step_), 0L) * timeStep_);
-    computeCurr_ = std::bind(&StatisticsConfiguration::getCurr, this);
-    return curr_;
-}
-
-eckit::DateTime StatisticsConfiguration::getCurr() const {
-    return curr_;
-}
-
-
-eckit::DateTime StatisticsConfiguration::computeWinStart() const {
-    ASSERT(opt_.solver_send_initial_condition());
-    winStart_ = curr();
-    computeWinStart_ = std::bind(&StatisticsConfiguration::getWinStart, this);
-    return winStart_;
-}
-
-eckit::DateTime StatisticsConfiguration::getWinStart() const {
-    return winStart_;
+    return epoch() + static_cast<eckit::Second>(std::max(step_, 0L) * timeStep_);
 }
 
 
@@ -241,6 +197,13 @@ double StatisticsConfiguration::missingValue() const {
 
 const std::string& StatisticsConfiguration::key() const {
     return key_;
+}
+
+eckit::DateTime StatisticsConfiguration::epoch() const {
+    return epoch_;
+}
+eckit::DateTime StatisticsConfiguration::curr() const {
+    return curr_;
 }
 
 }  // namespace multio::action::statistics_mtg2

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -32,8 +32,7 @@ StatisticsConfiguration::StatisticsConfiguration(const message::Metadata& md, co
     precision_{"none"},
     bitmapPresent_{false},
     missingValue_{std::numeric_limits<double>::quiet_NaN()},
-    key_{"unknown"},
-    logPrefix_{opt_.logPrefix()} {
+    key_{"unknown"} {
 
     // Associate local procedure pointers
     computeEpoch_ = std::bind(&StatisticsConfiguration::computeEpoch, this);
@@ -265,11 +264,6 @@ bool StatisticsConfiguration::bitmapPresent() const {
 
 double StatisticsConfiguration::missingValue() const {
     return missingValue_;
-};
-
-
-std::string StatisticsConfiguration::logPrefix() const {
-    return logPrefix_;
 };
 
 

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -2,7 +2,9 @@
 
 #include <limits.h>
 #include <unistd.h>
+#include <cstdint>
 #include <iomanip>
+#include <optional>
 #include <string>
 
 #include "eckit/exception/Exceptions.h"
@@ -18,22 +20,111 @@ namespace multio::action::statistics_mtg2 {
 
 namespace dm = multio::datamod;
 
+
+std::int64_t readDate(const message::Metadata& md) {
+    // NOTE: Currently no support for messages without step (from analysis)!
+    ASSERT(md.getOpt<std::int64_t>(dm::legacy::Step).has_value());
+    const auto dateVal = md.getOpt<std::int64_t>(dm::legacy::Date);
+    ASSERT(dateVal.has_value());
+    return *dateVal;
+}
+
+std::int64_t readTime(const message::Metadata& md) {
+    // NOTE: Currently no support for messages without step (from analysis)!
+    ASSERT(md.getOpt<std::int64_t>(dm::legacy::Step).has_value());
+    const auto timeVal = md.getOpt<std::int64_t>(dm::legacy::Time);
+    ASSERT(timeVal.has_value());
+    return *timeVal;
+}
+
+std::int64_t readLevel(const message::Metadata& md) {
+    if (auto level = md.getOpt<std::int64_t>(dm::legacy::Level); level) {
+        return *level;
+    }
+    else if (auto levelist = md.getOpt<std::int64_t>(dm::legacy::Levelist); levelist) {
+        return *levelist;
+    }
+    // if none of the above metadata options are present the default levtype is 0
+    return 0;
+}
+
+std::int64_t readTimeStep(const message::Metadata& md, int64_t defaultTimeStep) {
+    return md.getOpt<std::int64_t>(dm::legacy::TimeStep).value_or(defaultTimeStep);
+}
+
+std::int64_t readStep(const message::Metadata& md) {
+    // NOTE: Currently no support for messages without step (from analysis)!
+    const auto stepVal = md.getOpt<std::int64_t>(dm::legacy::Step);
+    ASSERT(stepVal.has_value());
+    return *stepVal;
+}
+
+std::string readParam(const message::Metadata& md) {
+    // TODO: use whole validated keyset...
+    if (const auto& grid = dm::parseEntry(dm::PARAM, md); grid.isSet()) {
+        return std::to_string(grid.get());
+    }
+    else if (auto paramId = md.getOpt<std::int64_t>(dm::legacy::ParamId); paramId) {
+        return std::to_string(*paramId);
+    }
+    throw eckit::SeriousBug{"Param metadata not present", Here()};
+}
+
+std::string readLevType(const message::Metadata& md) {
+    if (auto levType = md.getOpt<std::string>(dm::legacy::Levtype); levType) {
+        return *levType;
+    }
+    throw message::MetadataException("Levtype missing in metadata", Here());
+}
+
+std::string readGridType(const message::Metadata& md) {
+    // TODO use whole validated keyset...
+    if (const auto& grid = dm::parseEntry(dm::GRID, md); grid.isSet()) {
+        return grid.get();
+    }
+
+    // Truncation is always present when we are dealing with Spherical Harmonics
+    if (dm::parseEntry(dm::TRUNCATION, md).isSet()) {
+        return "none";
+    }
+
+    std::ostringstream os;
+    os << "Cannot find grid or truncation in metadata : " << md;
+    throw eckit::SeriousBug{os.str(), Here()};
+}
+
+std::string readPrecision(const message::Metadata& md) {
+    if (auto precision = md.getOpt<std::string>(dm::legacy::Precision); precision) {
+        return *precision;
+    }
+    throw eckit::SeriousBug{"precision metadata not present", Here()};
+}
+
+std::optional<double> readMissingValue(const message::Metadata& md) {
+    const auto missingVal = md.getOpt<double>(dm::legacy::MissingValue);
+    const auto bitMapPresent = md.getOpt<bool>(dm::legacy::BitmapPresent);
+
+    if (missingVal && bitMapPresent && *bitMapPresent) {
+        return missingVal;
+    }
+    return std::nullopt;
+}
+
+
 StatisticsConfiguration::StatisticsConfiguration(const message::Metadata& md, const message::Peer& src,
                                                  const StatisticsOptions& opt) :
     opt_{opt},
-    date_{0},
-    time_{0},
-    level_{0},
-    timeStep_{opt.timeStep()},
-    step_{0},
-    param_{"none"},
-    levType_{"none"},
-    gridType_{"none"},
-    precision_{"none"},
-    bitmapPresent_{false},
-    missingValue_{std::numeric_limits<double>::quiet_NaN()},
-    key_{"unknown"} {
-
+    date_{readDate(md)},
+    time_{readTime(md)},
+    level_{readLevel(md)},
+    timeStep_{readTimeStep(md, opt.timeStep())},
+    step_{readStep(md)},
+    param_{readParam(md)},
+    levType_{readLevType(md)},
+    gridType_{readGridType(md)},
+    precision_{readPrecision(md)},
+    missingValue_{readMissingValue(md)},
+    key_{generateKey(src)} {
     // Associate local procedure pointers
     computeEpoch_ = std::bind(&StatisticsConfiguration::computeEpoch, this);
     computeCurr_ = std::bind(&StatisticsConfiguration::computeCurr, this);
@@ -42,182 +133,54 @@ StatisticsConfiguration::StatisticsConfiguration(const message::Metadata& md, co
     computeBeginningOfDay_ = std::bind(&StatisticsConfiguration::computeBeginningOfDay, this);
     computeBeginningOfMonth_ = std::bind(&StatisticsConfiguration::computeBeginningOfMonth, this);
     computeBeginningOfYear_ = std::bind(&StatisticsConfiguration::computeBeginningOfYear, this);
-
-    // Read the metadata
-    readStartDate(md);
-    readStartTime(md);
-    readStep(md);
-    readTimeStep(md);
-    readLevel(md);
-    readParam(md);
-    readLevType(md);
-    readGridType(md);
-    readPrecision(md);
-    readMissingValue(md);
-
-    // Generate Key
-    generateKey(md, src);
-
-    return;
-};
+}
 
 StatisticsConfiguration::StatisticsConfiguration(const message::Message& msg, const StatisticsOptions& opt) :
     StatisticsConfiguration(msg.metadata(), msg.source(), opt) {};
 
 
-const std::string& StatisticsConfiguration::key() const {
-    return key_;
-};
-
-void StatisticsConfiguration::readPrecision(const message::Metadata& md) {
-    if (auto precision = md.getOpt<std::string>(dm::legacy::Precision); precision) {
-        precision_ = *precision;
-    }
-    else {
-        throw eckit::SeriousBug{"precision metadata not present", Here()};
-    }
-    return;
-};
-
-void StatisticsConfiguration::readGridType(const message::Metadata& md) {
-    // TODO use whole validated keyset...
-    if (const auto& grid = dm::parseEntry(dm::GRID, md); grid.isSet()) {
-        gridType_ = grid.get();
-        return;
-    }
-
-    // Truncation is always present when we are dealing with Spherical Harmonics
-    if (dm::parseEntry(dm::TRUNCATION, md).isSet()) {
-        return;
-    }
-
-    std::ostringstream os;
-    os << "Cannot find grid or truncation in metadata : " << md;
-    throw eckit::SeriousBug{os.str(), Here()};
-};
-
-void StatisticsConfiguration::readLevType(const message::Metadata& md) {
-    if (auto levType = md.getOpt<std::string>(dm::legacy::Levtype); levType) {
-        levType_ = *levType;
-    }
-    else {
-        throw message::MetadataException("Levtype missing in metadata", Here());
-    }
-    // if none of the above metadata options are present the default levtype is kept
-    return;
-};
-
-void StatisticsConfiguration::readParam(const message::Metadata& md) {
-
-    // TODO use whole validated keyset...
-    if (const auto& grid = dm::parseEntry(dm::PARAM, md); grid.isSet()) {
-        param_ = std::to_string(grid.get());
-    }
-
-    else if (auto paramId = md.getOpt<std::int64_t>(dm::legacy::ParamId); paramId) {
-        param_ = std::to_string(*paramId);
-    }
-    else {
-        throw eckit::SeriousBug{"Param metadata not present", Here()};
-    }
-    return;
-};
-
-
-void StatisticsConfiguration::readLevel(const message::Metadata& md) {
-    if (auto level = md.getOpt<std::int64_t>(dm::legacy::Level); level) {
-        level_ = *level;
-    }
-    else if (auto levelist = md.getOpt<std::int64_t>(dm::legacy::Levelist); levelist) {
-        level_ = *levelist;
-    }
-    // if none of the above metadata options are present the default levtype is kept
-
-    return;
-};
-
-void StatisticsConfiguration::readStartTime(const message::Metadata& md) {
-    // NOTE: Currently no support for messages without step (from analysis)!
-    ASSERT(md.getOpt<std::int64_t>(dm::legacy::Step).has_value());
-    const auto timeVal = md.getOpt<std::int64_t>(dm::legacy::Time);
-    ASSERT(timeVal.has_value());
-    time_ = *timeVal;
-};
-
-void StatisticsConfiguration::readStartDate(const message::Metadata& md) {
-    // NOTE: Currently no support for messages without step (from analysis)!
-    ASSERT(md.getOpt<std::int64_t>(dm::legacy::Step).has_value());
-    const auto dateVal = md.getOpt<std::int64_t>(dm::legacy::Date);
-    ASSERT(dateVal.has_value());
-    date_ = *dateVal;
-};
-
-
-void StatisticsConfiguration::readStep(const message::Metadata& md) {
-    // NOTE: Currently no support for messages without step (from analysis)!
-    const auto stepVal = md.getOpt<std::int64_t>(dm::legacy::Step);
-    ASSERT(stepVal.has_value());
-    step_ = *stepVal;
-};
-
-void StatisticsConfiguration::readTimeStep(const message::Metadata& md) {
-    timeStep_ = md.getOpt<std::int64_t>(dm::legacy::TimeStep).value_or(timeStep_);
-    return;
-};
-
-
-void StatisticsConfiguration::readMissingValue(const message::Metadata& md) {
-    const auto missingVal = md.getOpt<double>(dm::legacy::MissingValue);
-    const auto bitMapPresent = md.getOpt<bool>(dm::legacy::BitmapPresent);
-    bitmapPresent_ = missingVal && bitMapPresent && *bitMapPresent;
-    if (bitmapPresent_) {
-        missingValue_ = *missingVal;
-    }
-};
-
-
-void StatisticsConfiguration::generateKey(const message::Metadata& md, const message::Peer& src) {
+std::string StatisticsConfiguration::generateKey(const message::Peer& src) const {
     std::ostringstream os;
     os << param_ << "-" << level_ << "-" << levType_ << "-" << gridType_ << "-" << precision_ << "-" << src.group()
        << "_" << src.id();
-    key_ = os.str();
-};
+    return os.str();
+}
 
 
 eckit::DateTime StatisticsConfiguration::epoch() const {
     epoch_ = computeEpoch_();
     return epoch_;
-};
+}
 
 eckit::DateTime StatisticsConfiguration::curr() const {
     curr_ = computeCurr_();
     return curr_;
-};
+}
 
 eckit::DateTime StatisticsConfiguration::winStart() const {
     winStart_ = computeWinStart_();
     return winStart_;
-};
+}
 
 bool StatisticsConfiguration::beginningOfHour() const {
     auto ret = computeBeginningOfHour_();
     return ret;
-};
+}
 
 bool StatisticsConfiguration::beginningOfDay() const {
     auto ret = computeBeginningOfDay_();
     return ret;
-};
+}
 
 bool StatisticsConfiguration::beginningOfMonth() const {
     auto ret = computeBeginningOfMonth_();
     return ret;
-};
+}
 
 bool StatisticsConfiguration::beginningOfYear() const {
     auto ret = computeBeginningOfYear_();
     return ret;
-};
+}
 
 
 eckit::DateTime StatisticsConfiguration::computeEpoch() const {
@@ -231,18 +194,18 @@ eckit::DateTime StatisticsConfiguration::computeEpoch() const {
 
 eckit::DateTime StatisticsConfiguration::getEpoch() const {
     return epoch_;
-};
+}
 
 
 eckit::DateTime StatisticsConfiguration::computeCurr() const {
     curr_ = epoch() + static_cast<eckit::Second>(std::max((step_), 0L) * timeStep_);
     computeCurr_ = std::bind(&StatisticsConfiguration::getCurr, this);
     return curr_;
-};
+}
 
 eckit::DateTime StatisticsConfiguration::getCurr() const {
     return curr_;
-};
+}
 
 
 eckit::DateTime StatisticsConfiguration::computeWinStart() const {
@@ -250,21 +213,11 @@ eckit::DateTime StatisticsConfiguration::computeWinStart() const {
     winStart_ = curr();
     computeWinStart_ = std::bind(&StatisticsConfiguration::getWinStart, this);
     return winStart_;
-};
+}
 
 eckit::DateTime StatisticsConfiguration::getWinStart() const {
     return winStart_;
-};
-
-
-bool StatisticsConfiguration::bitmapPresent() const {
-    return bitmapPresent_;
-};
-
-
-double StatisticsConfiguration::missingValue() const {
-    return missingValue_;
-};
+}
 
 
 bool StatisticsConfiguration::computeBeginningOfHour() const {
@@ -274,11 +227,11 @@ bool StatisticsConfiguration::computeBeginningOfHour() const {
     beginningOfHour_ = (min == 0 && sec == 0);
     computeBeginningOfHour_ = std::bind(&StatisticsConfiguration::isBeginningOfHour, this);
     return beginningOfHour_;
-};
+}
 
 bool StatisticsConfiguration::isBeginningOfHour() const {
     return beginningOfHour_;
-};
+}
 
 bool StatisticsConfiguration::computeBeginningOfDay() const {
     eckit::DateTime now = curr();
@@ -288,11 +241,11 @@ bool StatisticsConfiguration::computeBeginningOfDay() const {
     beginningOfDay_ = (hour == 0 && min == 0 && sec == 0);
     computeBeginningOfDay_ = std::bind(&StatisticsConfiguration::isBeginningOfDay, this);
     return beginningOfDay_;
-};
+}
 
 bool StatisticsConfiguration::isBeginningOfDay() const {
     return beginningOfDay_;
-};
+}
 
 bool StatisticsConfiguration::computeBeginningOfMonth() const {
     eckit::DateTime now = curr();
@@ -303,11 +256,11 @@ bool StatisticsConfiguration::computeBeginningOfMonth() const {
     beginningOfMonth_ = (day == 1 && hour == 0 && min == 0 && sec == 0);
     computeBeginningOfMonth_ = std::bind(&StatisticsConfiguration::isBeginningOfMonth, this);
     return beginningOfMonth_;
-};
+}
 
 bool StatisticsConfiguration::isBeginningOfMonth() const {
     return beginningOfMonth_;
-};
+}
 
 bool StatisticsConfiguration::computeBeginningOfYear() const {
     eckit::DateTime now = curr();
@@ -319,42 +272,58 @@ bool StatisticsConfiguration::computeBeginningOfYear() const {
     beginningOfYear_ = (month == 1 && day == 1 && hour == 0 && min == 0 && sec == 0);
     computeBeginningOfYear_ = std::bind(&StatisticsConfiguration::isBeginningOfYear, this);
     return beginningOfYear_;
-};
+}
 
 bool StatisticsConfiguration::isBeginningOfYear() const {
     return beginningOfYear_;
-};
+}
 
+const StatisticsOptions& StatisticsConfiguration::options() const {
+    return opt_;
+}
 
 long StatisticsConfiguration::date() const {
     return date_;
-};
+}
 long StatisticsConfiguration::time() const {
     return time_;
-};
+}
 long StatisticsConfiguration::level() const {
     return level_;
-};
+}
 long StatisticsConfiguration::timeStep() const {
     return timeStep_;
-};
+}
 long StatisticsConfiguration::step() const {
     return step_;
-};
+}
 
 std::string StatisticsConfiguration::param() const {
     return param_;
-};
+}
 std::string StatisticsConfiguration::levType() const {
     return levType_;
-};
+}
 std::string StatisticsConfiguration::gridType() const {
     return gridType_;
-};
+}
 std::string StatisticsConfiguration::precision() const {
     return precision_;
-};
-const StatisticsOptions& StatisticsConfiguration::options() const {
-    return opt_;
-};
+}
+
+bool StatisticsConfiguration::bitmapPresent() const {
+    return missingValue_.has_value();
+}
+
+double StatisticsConfiguration::missingValue() const {
+    if (missingValue_) {
+        return *missingValue_;
+    }
+    return std::numeric_limits<double>::quiet_NaN();  // TODO: Remove fake value
+}
+
+const std::string& StatisticsConfiguration::key() const {
+    return key_;
+}
+
 }  // namespace multio::action::statistics_mtg2

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -153,19 +153,19 @@ const StatisticsOptions& StatisticsConfiguration::options() const {
     return opt_;
 }
 
-long StatisticsConfiguration::date() const {
+std::int64_t StatisticsConfiguration::date() const {
     return date_;
 }
-long StatisticsConfiguration::time() const {
+std::int64_t StatisticsConfiguration::time() const {
     return time_;
 }
-long StatisticsConfiguration::level() const {
+std::int64_t StatisticsConfiguration::level() const {
     return level_;
 }
-long StatisticsConfiguration::timeStep() const {
+std::int64_t StatisticsConfiguration::timeStep() const {
     return timeStep_;
 }
-long StatisticsConfiguration::step() const {
+std::int64_t StatisticsConfiguration::step() const {
     return step_;
 }
 

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -129,10 +129,6 @@ StatisticsConfiguration::StatisticsConfiguration(const message::Metadata& md, co
     computeEpoch_ = std::bind(&StatisticsConfiguration::computeEpoch, this);
     computeCurr_ = std::bind(&StatisticsConfiguration::computeCurr, this);
     computeWinStart_ = std::bind(&StatisticsConfiguration::computeWinStart, this);
-    computeBeginningOfHour_ = std::bind(&StatisticsConfiguration::computeBeginningOfHour, this);
-    computeBeginningOfDay_ = std::bind(&StatisticsConfiguration::computeBeginningOfDay, this);
-    computeBeginningOfMonth_ = std::bind(&StatisticsConfiguration::computeBeginningOfMonth, this);
-    computeBeginningOfYear_ = std::bind(&StatisticsConfiguration::computeBeginningOfYear, this);
 }
 
 StatisticsConfiguration::StatisticsConfiguration(const message::Message& msg, const StatisticsOptions& opt) :
@@ -160,26 +156,6 @@ eckit::DateTime StatisticsConfiguration::curr() const {
 eckit::DateTime StatisticsConfiguration::winStart() const {
     winStart_ = computeWinStart_();
     return winStart_;
-}
-
-bool StatisticsConfiguration::beginningOfHour() const {
-    auto ret = computeBeginningOfHour_();
-    return ret;
-}
-
-bool StatisticsConfiguration::beginningOfDay() const {
-    auto ret = computeBeginningOfDay_();
-    return ret;
-}
-
-bool StatisticsConfiguration::beginningOfMonth() const {
-    auto ret = computeBeginningOfMonth_();
-    return ret;
-}
-
-bool StatisticsConfiguration::beginningOfYear() const {
-    auto ret = computeBeginningOfYear_();
-    return ret;
 }
 
 
@@ -220,64 +196,6 @@ eckit::DateTime StatisticsConfiguration::getWinStart() const {
 }
 
 
-bool StatisticsConfiguration::computeBeginningOfHour() const {
-    eckit::DateTime now = curr();
-    long min = now.time().minutes();
-    long sec = now.time().seconds();
-    beginningOfHour_ = (min == 0 && sec == 0);
-    computeBeginningOfHour_ = std::bind(&StatisticsConfiguration::isBeginningOfHour, this);
-    return beginningOfHour_;
-}
-
-bool StatisticsConfiguration::isBeginningOfHour() const {
-    return beginningOfHour_;
-}
-
-bool StatisticsConfiguration::computeBeginningOfDay() const {
-    eckit::DateTime now = curr();
-    long hour = now.time().hours();
-    long min = now.time().minutes();
-    long sec = now.time().seconds();
-    beginningOfDay_ = (hour == 0 && min == 0 && sec == 0);
-    computeBeginningOfDay_ = std::bind(&StatisticsConfiguration::isBeginningOfDay, this);
-    return beginningOfDay_;
-}
-
-bool StatisticsConfiguration::isBeginningOfDay() const {
-    return beginningOfDay_;
-}
-
-bool StatisticsConfiguration::computeBeginningOfMonth() const {
-    eckit::DateTime now = curr();
-    long day = now.date().day();
-    long hour = now.time().hours();
-    long min = now.time().minutes();
-    long sec = now.time().seconds();
-    beginningOfMonth_ = (day == 1 && hour == 0 && min == 0 && sec == 0);
-    computeBeginningOfMonth_ = std::bind(&StatisticsConfiguration::isBeginningOfMonth, this);
-    return beginningOfMonth_;
-}
-
-bool StatisticsConfiguration::isBeginningOfMonth() const {
-    return beginningOfMonth_;
-}
-
-bool StatisticsConfiguration::computeBeginningOfYear() const {
-    eckit::DateTime now = curr();
-    long month = now.date().month();
-    long day = now.date().day();
-    long hour = now.time().hours();
-    long min = now.time().minutes();
-    long sec = now.time().seconds();
-    beginningOfYear_ = (month == 1 && day == 1 && hour == 0 && min == 0 && sec == 0);
-    computeBeginningOfYear_ = std::bind(&StatisticsConfiguration::isBeginningOfYear, this);
-    return beginningOfYear_;
-}
-
-bool StatisticsConfiguration::isBeginningOfYear() const {
-    return beginningOfYear_;
-}
-
 const StatisticsOptions& StatisticsConfiguration::options() const {
     return opt_;
 }
@@ -314,7 +232,6 @@ std::string StatisticsConfiguration::precision() const {
 bool StatisticsConfiguration::bitmapPresent() const {
     return missingValue_.has_value();
 }
-
 double StatisticsConfiguration::missingValue() const {
     if (missingValue_) {
         return *missingValue_;

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -45,16 +45,16 @@ StatisticsConfiguration::StatisticsConfiguration(const message::Metadata& md, co
     computeBeginningOfYear_ = std::bind(&StatisticsConfiguration::computeBeginningOfYear, this);
 
     // Read the metadata
-    readStartDate(md, opt);
-    readStartTime(md, opt);
-    readStep(md, opt);
-    readTimeStep(md, opt);
-    readLevel(md, opt);
-    readParam(md, opt);
-    readLevType(md, opt);
-    readGridType(md, opt);
-    readPrecision(md, opt);
-    readMissingValue(md, opt);
+    readStartDate(md);
+    readStartTime(md);
+    readStep(md);
+    readTimeStep(md);
+    readLevel(md);
+    readParam(md);
+    readLevType(md);
+    readGridType(md);
+    readPrecision(md);
+    readMissingValue(md);
 
     // Generate Key
     generateKey(md, src);
@@ -70,7 +70,7 @@ const std::string& StatisticsConfiguration::key() const {
     return key_;
 };
 
-void StatisticsConfiguration::readPrecision(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readPrecision(const message::Metadata& md) {
     if (auto precision = md.getOpt<std::string>(dm::legacy::Precision); precision) {
         precision_ = *precision;
     }
@@ -80,7 +80,7 @@ void StatisticsConfiguration::readPrecision(const message::Metadata& md, const S
     return;
 };
 
-void StatisticsConfiguration::readGridType(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readGridType(const message::Metadata& md) {
     // TODO use whole validated keyset...
     if (const auto& grid = dm::parseEntry(dm::GRID, md); grid.isSet()) {
         gridType_ = grid.get();
@@ -97,7 +97,7 @@ void StatisticsConfiguration::readGridType(const message::Metadata& md, const St
     throw eckit::SeriousBug{os.str(), Here()};
 };
 
-void StatisticsConfiguration::readLevType(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readLevType(const message::Metadata& md) {
     if (auto levType = md.getOpt<std::string>(dm::legacy::Levtype); levType) {
         levType_ = *levType;
     }
@@ -108,7 +108,7 @@ void StatisticsConfiguration::readLevType(const message::Metadata& md, const Sta
     return;
 };
 
-void StatisticsConfiguration::readParam(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readParam(const message::Metadata& md) {
 
     // TODO use whole validated keyset...
     if (const auto& grid = dm::parseEntry(dm::PARAM, md); grid.isSet()) {
@@ -125,7 +125,7 @@ void StatisticsConfiguration::readParam(const message::Metadata& md, const Stati
 };
 
 
-void StatisticsConfiguration::readLevel(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readLevel(const message::Metadata& md) {
     if (auto level = md.getOpt<std::int64_t>(dm::legacy::Level); level) {
         level_ = *level;
     }
@@ -137,7 +137,7 @@ void StatisticsConfiguration::readLevel(const message::Metadata& md, const Stati
     return;
 };
 
-void StatisticsConfiguration::readStartTime(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readStartTime(const message::Metadata& md) {
     // NOTE: Currently no support for messages without step (from analysis)!
     ASSERT(md.getOpt<std::int64_t>(dm::legacy::Step).has_value());
     const auto timeVal = md.getOpt<std::int64_t>(dm::legacy::Time);
@@ -145,7 +145,7 @@ void StatisticsConfiguration::readStartTime(const message::Metadata& md, const S
     time_ = *timeVal;
 };
 
-void StatisticsConfiguration::readStartDate(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readStartDate(const message::Metadata& md) {
     // NOTE: Currently no support for messages without step (from analysis)!
     ASSERT(md.getOpt<std::int64_t>(dm::legacy::Step).has_value());
     const auto dateVal = md.getOpt<std::int64_t>(dm::legacy::Date);
@@ -154,20 +154,20 @@ void StatisticsConfiguration::readStartDate(const message::Metadata& md, const S
 };
 
 
-void StatisticsConfiguration::readStep(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readStep(const message::Metadata& md) {
     // NOTE: Currently no support for messages without step (from analysis)!
     const auto stepVal = md.getOpt<std::int64_t>(dm::legacy::Step);
     ASSERT(stepVal.has_value());
     step_ = *stepVal;
 };
 
-void StatisticsConfiguration::readTimeStep(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readTimeStep(const message::Metadata& md) {
     timeStep_ = md.getOpt<std::int64_t>(dm::legacy::TimeStep).value_or(timeStep_);
     return;
 };
 
 
-void StatisticsConfiguration::readMissingValue(const message::Metadata& md, const StatisticsOptions& opt) {
+void StatisticsConfiguration::readMissingValue(const message::Metadata& md) {
     const auto missingVal = md.getOpt<double>(dm::legacy::MissingValue);
     const auto bitMapPresent = md.getOpt<bool>(dm::legacy::BitmapPresent);
     bitmapPresent_ = missingVal && bitMapPresent && *bitMapPresent;

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -169,16 +169,16 @@ long StatisticsConfiguration::step() const {
     return step_;
 }
 
-std::string StatisticsConfiguration::param() const {
+const std::string& StatisticsConfiguration::param() const {
     return param_;
 }
-std::string StatisticsConfiguration::levType() const {
+const std::string& StatisticsConfiguration::levType() const {
     return levType_;
 }
-std::string StatisticsConfiguration::gridType() const {
+const std::string& StatisticsConfiguration::gridType() const {
     return gridType_;
 }
-std::string StatisticsConfiguration::precision() const {
+const std::string& StatisticsConfiguration::precision() const {
     return precision_;
 }
 
@@ -196,10 +196,10 @@ const std::string& StatisticsConfiguration::key() const {
     return key_;
 }
 
-eckit::DateTime StatisticsConfiguration::epoch() const {
+const eckit::DateTime& StatisticsConfiguration::epoch() const {
     return epoch_;
 }
-eckit::DateTime StatisticsConfiguration::curr() const {
+const eckit::DateTime& StatisticsConfiguration::curr() const {
     return curr_;
 }
 

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -192,7 +192,7 @@ double StatisticsConfiguration::missingValue() const {
     if (missingValue_) {
         return *missingValue_;
     }
-    return std::numeric_limits<double>::quiet_NaN();  // TODO: Remove fake value
+    throw eckit::SeriousBug("Missing value is undefined!", Here());
 }
 
 const std::string& StatisticsConfiguration::key() const {

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.cc
@@ -1,20 +1,17 @@
-#include "multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h"
+#include "StatisticsConfiguration.h"
 
 #include <limits.h>
 #include <unistd.h>
+
 #include <cstdint>
-#include <iomanip>
 #include <optional>
 #include <string>
 
 #include "eckit/exception/Exceptions.h"
-#include "eckit/filesystem/PathName.h"
 
-#include "multio/LibMultio.h"
 #include "multio/datamod/ContainerInterop.h"
 #include "multio/datamod/Glossary.h"
-#include "multio/datamod/MarsMiscGeo.h"
-#include "multio/util/Substitution.h"
+#include "multio/datamod/MarsKeys.h"
 
 namespace multio::action::statistics_mtg2 {
 

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
@@ -55,10 +55,10 @@ public:
     std::int64_t timeStep() const;
     std::int64_t step() const;
 
-    std::string param() const;
-    std::string levType() const;
-    std::string gridType() const;
-    std::string precision() const;
+    const std::string& param() const;
+    const std::string& levType() const;
+    const std::string& gridType() const;
+    const std::string& precision() const;
 
     // Handle missing values
     bool bitmapPresent() const;
@@ -66,8 +66,8 @@ public:
 
     const std::string& key() const;
 
-    eckit::DateTime epoch() const;
-    eckit::DateTime curr() const;
+    const eckit::DateTime& epoch() const;
+    const eckit::DateTime& curr() const;
 };
 
 }  // namespace multio::action::statistics_mtg2

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
@@ -80,16 +80,16 @@ private:
 
     void generateKey(const message::Metadata& md, const message::Peer& src);
 
-    void readPrecision(const message::Metadata& md, const StatisticsOptions& opt);
-    void readGridType(const message::Metadata& md, const StatisticsOptions& opt);
-    void readLevType(const message::Metadata& md, const StatisticsOptions& opt);
-    void readLevel(const message::Metadata& md, const StatisticsOptions& opt);
-    void readParam(const message::Metadata& md, const StatisticsOptions& opt);
-    void readStartTime(const message::Metadata& md, const StatisticsOptions& opt);
-    void readStartDate(const message::Metadata& md, const StatisticsOptions& opt);
-    void readStep(const message::Metadata& md, const StatisticsOptions& opt);
-    void readTimeStep(const message::Metadata& md, const StatisticsOptions& opt);
-    void readMissingValue(const message::Metadata& md, const StatisticsOptions& opt);
+    void readPrecision(const message::Metadata& md);
+    void readGridType(const message::Metadata& md);
+    void readLevType(const message::Metadata& md);
+    void readLevel(const message::Metadata& md);
+    void readParam(const message::Metadata& md);
+    void readStartTime(const message::Metadata& md);
+    void readStartDate(const message::Metadata& md);
+    void readStep(const message::Metadata& md);
+    void readTimeStep(const message::Metadata& md);
+    void readMissingValue(const message::Metadata& md);
 
 
 public:

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
@@ -16,30 +16,27 @@ private:
     const StatisticsOptions& opt_;
 
     // Metadata to be extracted from the message
-    long date_;
-    long time_;
-    long level_;
-    long timeStep_;
-    long step_;
+    const std::int64_t date_;
+    const std::int64_t time_;
+    const std::int64_t level_;
+    const std::int64_t timeStep_;
+    const std::int64_t step_;
 
-    std::string param_;
-    std::string levType_;
-    std::string gridType_;
-    std::string precision_;
+    const std::string param_;
+    const std::string levType_;
+    const std::string gridType_;
+    const std::string precision_;
 
     // Handle missing values
-    bool bitmapPresent_;
-    double missingValue_;
+    const std::optional<double> missingValue_;
 
     // Unique key used for statistics map
-    std::string key_;
+    const std::string key_;
 
 
     // Timing utils
     mutable eckit::DateTime epoch_;
-    mutable eckit::DateTime prev_;
     mutable eckit::DateTime curr_;
-    mutable eckit::DateTime next_;
     mutable eckit::DateTime winStart_;
 
     mutable bool beginningOfHour_;
@@ -48,9 +45,7 @@ private:
     mutable bool beginningOfYear_;
 
     mutable std::function<eckit::DateTime()> computeEpoch_;
-    mutable std::function<eckit::DateTime()> computePrev_;
     mutable std::function<eckit::DateTime()> computeCurr_;
-    mutable std::function<eckit::DateTime()> computeNext_;
     mutable std::function<eckit::DateTime()> computeWinStart_;
 
     mutable std::function<bool()> computeBeginningOfHour_;
@@ -77,18 +72,7 @@ private:
     bool computeBeginningOfYear() const;
     bool isBeginningOfYear() const;
 
-    void generateKey(const message::Metadata& md, const message::Peer& src);
-
-    void readPrecision(const message::Metadata& md);
-    void readGridType(const message::Metadata& md);
-    void readLevType(const message::Metadata& md);
-    void readLevel(const message::Metadata& md);
-    void readParam(const message::Metadata& md);
-    void readStartTime(const message::Metadata& md);
-    void readStartDate(const message::Metadata& md);
-    void readStep(const message::Metadata& md);
-    void readTimeStep(const message::Metadata& md);
-    void readMissingValue(const message::Metadata& md);
+    std::string generateKey(const message::Peer& src) const;
 
 
 public:
@@ -96,13 +80,12 @@ public:
     StatisticsConfiguration(const message::Message& msg, const StatisticsOptions& opt);
 
     const StatisticsOptions& options() const;
-    const std::string& key() const;
 
-    long date() const;
-    long time() const;
-    long level() const;
-    long timeStep() const;
-    long step() const;
+    std::int64_t date() const;
+    std::int64_t time() const;
+    std::int64_t level() const;
+    std::int64_t timeStep() const;
+    std::int64_t step() const;
 
     std::string param() const;
     std::string levType() const;
@@ -113,6 +96,7 @@ public:
     bool bitmapPresent() const;
     double missingValue() const;
 
+    const std::string& key() const;
 
     eckit::DateTime epoch() const;
     eckit::DateTime curr() const;

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
@@ -1,10 +1,8 @@
 #pragma once
 
-#include "eckit/config/LocalConfiguration.h"
+#include "StatisticsOptions.h"
+
 #include "eckit/types/DateTime.h"
-#include "multio/action/Action.h"
-#include "multio/action/statistics-mtg2/cfg/StatisticsOptions.h"
-#include "multio/config/ComponentConfiguration.h"
 #include "multio/message/Message.h"
 
 namespace multio::action::statistics_mtg2 {

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
@@ -26,7 +26,6 @@ private:
     std::string levType_;
     std::string gridType_;
     std::string precision_;
-    std::string logPrefix_;
 
     // Handle missing values
     bool bitmapPresent_;
@@ -109,7 +108,6 @@ public:
     std::string levType() const;
     std::string gridType() const;
     std::string precision() const;
-    std::string logPrefix() const;
 
     // Handle missing values
     bool bitmapPresent() const;

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
@@ -33,26 +33,14 @@ private:
     // Unique key used for statistics map
     const std::string key_;
 
-
     // Timing utils
     mutable eckit::DateTime epoch_;
     mutable eckit::DateTime curr_;
     mutable eckit::DateTime winStart_;
 
-    mutable bool beginningOfHour_;
-    mutable bool beginningOfDay_;
-    mutable bool beginningOfMonth_;
-    mutable bool beginningOfYear_;
-
     mutable std::function<eckit::DateTime()> computeEpoch_;
     mutable std::function<eckit::DateTime()> computeCurr_;
     mutable std::function<eckit::DateTime()> computeWinStart_;
-
-    mutable std::function<bool()> computeBeginningOfHour_;
-    mutable std::function<bool()> computeBeginningOfDay_;
-    mutable std::function<bool()> computeBeginningOfMonth_;
-    mutable std::function<bool()> computeBeginningOfYear_;
-
 
     // ---------------------------------------------------------------------------------------------
 
@@ -62,15 +50,6 @@ private:
     eckit::DateTime getCurr() const;
     eckit::DateTime computeWinStart() const;
     eckit::DateTime getWinStart() const;
-
-    bool computeBeginningOfHour() const;
-    bool isBeginningOfHour() const;
-    bool computeBeginningOfDay() const;
-    bool isBeginningOfDay() const;
-    bool computeBeginningOfMonth() const;
-    bool isBeginningOfMonth() const;
-    bool computeBeginningOfYear() const;
-    bool isBeginningOfYear() const;
 
     std::string generateKey(const message::Peer& src) const;
 
@@ -101,11 +80,6 @@ public:
     eckit::DateTime epoch() const;
     eckit::DateTime curr() const;
     eckit::DateTime winStart() const;
-
-    bool beginningOfHour() const;
-    bool beginningOfDay() const;
-    bool beginningOfMonth() const;
-    bool beginningOfYear() const;
 };
 
 }  // namespace multio::action::statistics_mtg2

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsConfiguration.h
@@ -34,24 +34,15 @@ private:
     const std::string key_;
 
     // Timing utils
-    mutable eckit::DateTime epoch_;
-    mutable eckit::DateTime curr_;
-    mutable eckit::DateTime winStart_;
-
-    mutable std::function<eckit::DateTime()> computeEpoch_;
-    mutable std::function<eckit::DateTime()> computeCurr_;
-    mutable std::function<eckit::DateTime()> computeWinStart_;
+    const eckit::DateTime epoch_;
+    const eckit::DateTime curr_;
 
     // ---------------------------------------------------------------------------------------------
 
-    eckit::DateTime computeEpoch() const;
-    eckit::DateTime getEpoch() const;
-    eckit::DateTime computeCurr() const;
-    eckit::DateTime getCurr() const;
-    eckit::DateTime computeWinStart() const;
-    eckit::DateTime getWinStart() const;
-
     std::string generateKey(const message::Peer& src) const;
+
+    eckit::DateTime computeEpoch() const;
+    eckit::DateTime computeCurr() const;
 
 
 public:
@@ -79,7 +70,6 @@ public:
 
     eckit::DateTime epoch() const;
     eckit::DateTime curr() const;
-    eckit::DateTime winStart() const;
 };
 
 }  // namespace multio::action::statistics_mtg2

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
@@ -208,7 +208,7 @@ const std::string& StatisticsOptions::solverResetAccumulatedFieldsEvery() const 
     return solverResetAccumulatedFieldsEvery_;
 }
 
-std::optional<long> StatisticsOptions::valueCountThreshold() const {
+std::optional<std::int64_t> StatisticsOptions::valueCountThreshold() const {
     return valueCountThreshold_;
 }
 

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
@@ -88,7 +88,7 @@ std::string parseWindowType(const eckit::LocalConfiguration& cfg) {
     return windowType;
 }
 
-std::string parseSolverResetAccumulatedFields(const eckit::LocalConfiguration& cfg) {
+std::string parseSolverResetAccumulatedFieldsEvery(const eckit::LocalConfiguration& cfg) {
     // Used in the deaccumulate action to not deaccumulate twice
     const auto accumulatedFieldsResetFreqency = cfg.getString("solver-reset-accumulate-fields-every", "month");
     if (accumulatedFieldsResetFreqency != "hour" && accumulatedFieldsResetFreqency != "day"
@@ -149,7 +149,7 @@ std::vector<std::pair<std::string, std::string>> parseSetMetadata(const eckit::L
 
 StatisticsOptions::StatisticsOptions(const eckit::LocalConfiguration& cfg) :
     timeStep_{parseTimeStep(cfg)},
-    solverSendInitStep_{parseInitialConditionPresent(cfg)},  // TODO: rename var
+    initialConditionPresent_{parseInitialConditionPresent(cfg)},
     readRestart_{parseReadRestart(cfg)},
     writeRestart_{parseWriteRestart(cfg)},
     debugRestart_{parseDebugRestart(cfg)},
@@ -159,7 +159,7 @@ StatisticsOptions::StatisticsOptions(const eckit::LocalConfiguration& cfg) :
     restartLib_{parseRestartLib(cfg)},
     logPrefix_{parseRestartPrefix(cfg)},
     windowType_{parseWindowType(cfg)},
-    accumulatedFieldsResetFreqency_{parseSolverResetAccumulatedFields(cfg)},  // TODO: rename var
+    solverResetAccumulatedFieldsEvery_{parseSolverResetAccumulatedFieldsEvery(cfg)},
     valueCountThreshold_{parseValueCountThreshold(cfg)},
     disableStrictMapping_{parseDisableStrictMapping(cfg)},
     disableSquashing_{parseDisableSquashing(cfg)},
@@ -169,8 +169,8 @@ StatisticsOptions::StatisticsOptions(const eckit::LocalConfiguration& cfg) :
 std::int64_t StatisticsOptions::timeStep() const {
     return timeStep_;
 }
-bool StatisticsOptions::solver_send_initial_condition() const {
-    return solverSendInitStep_;
+bool StatisticsOptions::initialConditionPresent() const {
+    return initialConditionPresent_;
 }
 
 bool StatisticsOptions::readRestart() const {
@@ -201,8 +201,8 @@ const std::string& StatisticsOptions::logPrefix() const {
 const std::string& StatisticsOptions::windowType() const {
     return windowType_;
 }
-const std::string& StatisticsOptions::solverResetAccumulatedFields() const {
-    return accumulatedFieldsResetFreqency_;
+const std::string& StatisticsOptions::solverResetAccumulatedFieldsEvery() const {
+    return solverResetAccumulatedFieldsEvery_;
 }
 
 std::optional<long> StatisticsOptions::valueCountThreshold() const {

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
@@ -35,17 +35,17 @@ StatisticsOptions::StatisticsOptions(const config::ComponentConfiguration& compC
         parseWriteRestart(options);
         parseDebugRestart(options);
         parseReadRestart(options);
-        parseRestartPath(compConf, options);
-        parseRestartPrefix(compConf, options);
+        parseRestartPath(options);
+        parseRestartPrefix(options);
         parseRestartLib(options);
-        parseRestartTime(compConf, options);
-        parseLogPrefix(compConf, options);
-        parseWindowType(compConf, options);
-        parseSolverResetAccumulatedFields(compConf, options);
-        parseValueCountThreshold(compConf, options);
-        parseDisableStrictMapping(compConf, options);
+        parseRestartTime(options);
+        parseLogPrefix(options);
+        parseWindowType(options);
+        parseSolverResetAccumulatedFields(options);
+        parseValueCountThreshold(options);
+        parseDisableStrictMapping(options);
         parseDisableSquashing(options);
-        parseSetMetadata(compConf, options);
+        parseSetMetadata(options);
     }
 
 
@@ -117,8 +117,7 @@ void StatisticsOptions::parseReadRestart(const eckit::LocalConfiguration& cfg) {
 };
 
 
-void StatisticsOptions::parseRestartPath(const config::ComponentConfiguration& compConf,
-                                         const eckit::LocalConfiguration& cfg) {
+void StatisticsOptions::parseRestartPath(const eckit::LocalConfiguration& cfg) {
     // Read the path used to restart statistics
     // Default value is "."
     restartPath_ = cfg.getString("restart-path", ".");
@@ -132,8 +131,7 @@ void StatisticsOptions::parseRestartPath(const config::ComponentConfiguration& c
 };
 
 
-void StatisticsOptions::parseRestartTime(const config::ComponentConfiguration& compConf,
-                                         const eckit::LocalConfiguration& cfg) {
+void StatisticsOptions::parseRestartTime(const eckit::LocalConfiguration& cfg) {
     // Read the path used to restart statistics
     // Default value is "latest"
     restartTime_ = cfg.getString("restart-time", "latest");
@@ -141,8 +139,7 @@ void StatisticsOptions::parseRestartTime(const config::ComponentConfiguration& c
 };
 
 
-void StatisticsOptions::parseRestartPrefix(const config::ComponentConfiguration& compConf,
-                                           const eckit::LocalConfiguration& cfg) {
+void StatisticsOptions::parseRestartPrefix(const eckit::LocalConfiguration& cfg) {
     // Prefix used for the restart file names in order
     // to make the file name unique across different plans
     restartPrefix_ = cfg.getString("restart-prefix", "StatisticsDump");
@@ -155,14 +152,12 @@ void StatisticsOptions::parseRestartLib(const eckit::LocalConfiguration& cfg) {
 };
 
 
-void StatisticsOptions::parseLogPrefix(const config::ComponentConfiguration& compConf,
-                                       const eckit::LocalConfiguration& cfg) {
+void StatisticsOptions::parseLogPrefix(const eckit::LocalConfiguration& cfg) {
     logPrefix_ = cfg.getString("log-prefix", "Plan");
     return;
 };
 
-void StatisticsOptions::parseWindowType(const config::ComponentConfiguration& compConf,
-                                        const eckit::LocalConfiguration& cfg) {
+void StatisticsOptions::parseWindowType(const eckit::LocalConfiguration& cfg) {
     windowType_ = cfg.getString("window-type", "forward-offset");
     if (windowType_ != "forward-offset" && windowType_ != "backward-offset") {
         std::ostringstream os;
@@ -172,8 +167,7 @@ void StatisticsOptions::parseWindowType(const config::ComponentConfiguration& co
     return;
 };
 
-void StatisticsOptions::parseSolverResetAccumulatedFields(const config::ComponentConfiguration& compConf,
-                                                          const eckit::LocalConfiguration& cfg) {
+void StatisticsOptions::parseSolverResetAccumulatedFields(const eckit::LocalConfiguration& cfg) {
     // Used in the deaccumulate action to not deaccumulate twice
     accumulatedFieldsResetFreqency_ = cfg.getString("solver-reset-accumulate-fields-every", "month");
 
@@ -187,8 +181,7 @@ void StatisticsOptions::parseSolverResetAccumulatedFields(const config::Componen
     return;
 };
 
-void StatisticsOptions::parseValueCountThreshold(const config::ComponentConfiguration& compConf,
-                                                 const eckit::LocalConfiguration& cfg) {
+void StatisticsOptions::parseValueCountThreshold(const eckit::LocalConfiguration& cfg) {
     long threshold = cfg.getLong("value-count-threshold", -1);
 
     if (threshold == -1) {
@@ -205,8 +198,7 @@ void StatisticsOptions::parseValueCountThreshold(const config::ComponentConfigur
     throw eckit::UserError(os.str(), Here());
 }
 
-void StatisticsOptions::parseDisableStrictMapping(const config::ComponentConfiguration& compConf,
-                                                  const eckit::LocalConfiguration& cfg) {
+void StatisticsOptions::parseDisableStrictMapping(const eckit::LocalConfiguration& cfg) {
     std::optional<bool> r;
     r = util::parseBool(cfg, "disable-strict-mapping", false);
     if (r) {
@@ -230,8 +222,7 @@ void StatisticsOptions::parseDisableSquashing(const eckit::LocalConfiguration& c
     }
 }
 
-void StatisticsOptions::parseSetMetadata(const config::ComponentConfiguration& compConf,
-                                         const eckit::LocalConfiguration& cfg) {
+void StatisticsOptions::parseSetMetadata(const eckit::LocalConfiguration& cfg) {
     if (!cfg.has("set-metadata")) {
         return;
     }

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
@@ -1,6 +1,9 @@
+#include "StatisticsOptions.h"
 
-#include "multio/action/statistics-mtg2/cfg/StatisticsOptions.h"
-#include "eckit/config/LocalConfiguration.h"
+#include "eckit/exception/Exceptions.h"
+
+#include "eckit/filesystem/PathName.h"
+#include "multio/util/Substitution.h"
 
 namespace multio::action::statistics_mtg2 {
 

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.cc
@@ -1,196 +1,114 @@
 
 #include "multio/action/statistics-mtg2/cfg/StatisticsOptions.h"
+#include "eckit/config/LocalConfiguration.h"
 
 namespace multio::action::statistics_mtg2 {
 
-
-StatisticsOptions::StatisticsOptions(const config::ComponentConfiguration& compConf) :
-    timeStep_{3600},
-    solverSendInitStep_{false},
-    readRestart_{false},
-    writeRestart_{false},
-    debugRestart_{false},
-    restartTime_{"latest"},  // 00000000-000000
-    restartPath_{"."},
-    restartPrefix_{"StatisticsRestartFile"},
-    restartLib_{"fstream_io"},
-    logPrefix_{"Plan"},
-    windowType_{"forward-offset"},
-    accumulatedFieldsResetFreqency_{"month"},
-    valueCountThreshold_{},
-    disableStrictMapping_(false),
-    setMetadata_{} {
-    // Dump usage
-    if (compConf.parsedConfig().has("help")) {
-        usage();
-        throw eckit::UserError{"Usage requested", Here()};
-    }
-
-
-    // Read the options
-    if (compConf.parsedConfig().has("options")) {
-        const auto& options = compConf.parsedConfig().getSubConfiguration("options");
-        parseTimeStep(options);
-        parseInitialConditionPresent(options);
-        parseWriteRestart(options);
-        parseDebugRestart(options);
-        parseReadRestart(options);
-        parseRestartPath(options);
-        parseRestartPrefix(options);
-        parseRestartLib(options);
-        parseRestartTime(options);
-        parseLogPrefix(options);
-        parseWindowType(options);
-        parseSolverResetAccumulatedFields(options);
-        parseValueCountThreshold(options);
-        parseDisableStrictMapping(options);
-        parseDisableSquashing(options);
-        parseSetMetadata(options);
-    }
-
-
-    // dump all the options
-    dumpOptions();
-
-    return;
-};
-
-
-void StatisticsOptions::parseTimeStep(const eckit::LocalConfiguration& cfg) {
+std::int64_t parseTimeStep(const eckit::LocalConfiguration& cfg) {
     // How many seconds in a timestep
-    timeStep_ = cfg.getLong("time-step", 3600L);
-    return;
-};
+    return cfg.getLong("time-step", 3600L);
+}
 
-void StatisticsOptions::parseInitialConditionPresent(const eckit::LocalConfiguration& cfg) {
+bool parseInitialConditionPresent(const eckit::LocalConfiguration& cfg) {
     // Used to determine if the solver emit the initial condition.
     // This is a relevant information for statistics computations.
     // At the moment ifs emit the initial condition and nemo not.
     // Default value is false so that nemo can work without options.
-    solverSendInitStep_ = cfg.getBool("initial-condition-present", false);
-    return;
-};
-
-void StatisticsOptions::parseWriteRestart(const eckit::LocalConfiguration& cfg) {
-    // Used to determine if the simulation need to save/load
-    // restart files.
-    std::optional<bool> r;
-    r = util::parseBool(cfg, "write-restart", false);
+    const auto r = util::parseBool(cfg, "initial-condition-present", false);
     if (r) {
-        writeRestart_ = *r;
+        return *r;
     }
-    else {
-        usage();
-        throw eckit::SeriousBug{"Unable to read restart", Here()};
-    }
-    return;
-};
+    throw eckit::SeriousBug{"Unable to read boolean initial-condition-present", Here()};
+}
 
-void StatisticsOptions::parseDebugRestart(const eckit::LocalConfiguration& cfg) {
-    // Used to determine if the simulation need to save/load
-    // restart files.
-    std::optional<bool> r;
-    r = util::parseBool(cfg, "debug-restart", false);
+bool parseReadRestart(const eckit::LocalConfiguration& cfg) {
+    // Used to determine if the simulation need to load restart files
+    const auto r = util::parseBool(cfg, "read-restart", false);
     if (r) {
-        debugRestart_ = *r;
+        return *r;
     }
-    else {
-        usage();
-        throw eckit::SeriousBug{"Unable to read restart", Here()};
-    }
-    return;
-};
+    throw eckit::SeriousBug{"Unable to read boolean read-restart", Here()};
+}
 
-void StatisticsOptions::parseReadRestart(const eckit::LocalConfiguration& cfg) {
-    // Used to determine if the simulation need to save/load
-    // restart files.
-    std::optional<bool> r;
-    r = util::parseBool(cfg, "read-restart", false);
+bool parseWriteRestart(const eckit::LocalConfiguration& cfg) {
+    // Used to determine if the simulation need to save restart files
+    const auto r = util::parseBool(cfg, "write-restart", false);
     if (r) {
-        readRestart_ = *r;
+        return *r;
     }
-    else {
-        usage();
-        throw eckit::SeriousBug{"Unable to read restart", Here()};
+    throw eckit::SeriousBug{"Unable to read boolean write-restart", Here()};
+}
+
+bool parseDebugRestart(const eckit::LocalConfiguration& cfg) {
+    const auto r = util::parseBool(cfg, "debug-restart", false);
+    if (r) {
+        return *r;
     }
-    return;
-};
+    throw eckit::SeriousBug{"Unable to read boolean debug-restart", Here()};
+}
 
+std::string parseRestartTime(const eckit::LocalConfiguration& cfg) {
+    // Used to determine which file to restart from
+    return cfg.getString("restart-time", "latest");
+}
 
-void StatisticsOptions::parseRestartPath(const eckit::LocalConfiguration& cfg) {
-    // Read the path used to restart statistics
-    // Default value is "."
-    restartPath_ = cfg.getString("restart-path", ".");
-    eckit::PathName path{restartPath_};
+std::string parseRestartPath(const eckit::LocalConfiguration& cfg) {
+    // Path where restart files are loaded from / saved to
+    const auto restartPath = cfg.getString("restart-path", ".");
+    eckit::PathName path{restartPath};
     if (!path.exists() || !path.isDir()) {
         std::ostringstream os;
-        os << "Restart path does not exist :: " << restartPath_ << std::endl;
+        os << "Restart path does not exist :: " << restartPath << std::endl;
         throw eckit::UserError{os.str(), Here()};
     }
-    return;
-};
+    return restartPath;
+}
 
-
-void StatisticsOptions::parseRestartTime(const eckit::LocalConfiguration& cfg) {
-    // Read the path used to restart statistics
-    // Default value is "latest"
-    restartTime_ = cfg.getString("restart-time", "latest");
-    return;
-};
-
-
-void StatisticsOptions::parseRestartPrefix(const eckit::LocalConfiguration& cfg) {
+std::string parseRestartPrefix(const eckit::LocalConfiguration& cfg) {
     // Prefix used for the restart file names in order
     // to make the file name unique across different plans
-    restartPrefix_ = cfg.getString("restart-prefix", "StatisticsDump");
-    return;
-};
+    return cfg.getString("restart-prefix", "StatisticsDump");
+}
 
-void StatisticsOptions::parseRestartLib(const eckit::LocalConfiguration& cfg) {
-    restartLib_ = cfg.getString("restart-lib", "fstream_io");
-    return;
-};
+std::string parseRestartLib(const eckit::LocalConfiguration& cfg) {
+    return cfg.getString("restart-lib", "fstream_io");
+}
 
+std::string parseLogPrefix(const eckit::LocalConfiguration& cfg) {
+    return cfg.getString("log-prefix", "Plan");
+}
 
-void StatisticsOptions::parseLogPrefix(const eckit::LocalConfiguration& cfg) {
-    logPrefix_ = cfg.getString("log-prefix", "Plan");
-    return;
-};
-
-void StatisticsOptions::parseWindowType(const eckit::LocalConfiguration& cfg) {
-    windowType_ = cfg.getString("window-type", "forward-offset");
-    if (windowType_ != "forward-offset" && windowType_ != "backward-offset") {
+std::string parseWindowType(const eckit::LocalConfiguration& cfg) {
+    const auto windowType = cfg.getString("window-type", "forward-offset");
+    if (windowType != "forward-offset" && windowType != "backward-offset") {
         std::ostringstream os;
-        os << "Invalid window type :: " << windowType_ << std::endl;
+        os << "Invalid window type :: " << windowType << std::endl;
         throw eckit::UserError(os.str(), Here());
     }
-    return;
-};
+    return windowType;
+}
 
-void StatisticsOptions::parseSolverResetAccumulatedFields(const eckit::LocalConfiguration& cfg) {
+std::string parseSolverResetAccumulatedFields(const eckit::LocalConfiguration& cfg) {
     // Used in the deaccumulate action to not deaccumulate twice
-    accumulatedFieldsResetFreqency_ = cfg.getString("solver-reset-accumulate-fields-every", "month");
-
-    if (accumulatedFieldsResetFreqency_ != "hour" && accumulatedFieldsResetFreqency_ != "day"
-        && accumulatedFieldsResetFreqency_ != "month" && accumulatedFieldsResetFreqency_ != "year"
-        && accumulatedFieldsResetFreqency_ != "never") {
+    const auto accumulatedFieldsResetFreqency = cfg.getString("solver-reset-accumulate-fields-every", "month");
+    if (accumulatedFieldsResetFreqency != "hour" && accumulatedFieldsResetFreqency != "day"
+        && accumulatedFieldsResetFreqency != "month" && accumulatedFieldsResetFreqency != "year"
+        && accumulatedFieldsResetFreqency != "never") {
         std::ostringstream os;
-        os << "Invalid reset period of accumulated fields :: " << accumulatedFieldsResetFreqency_ << std::endl;
+        os << "Invalid reset period of accumulated fields :: " << accumulatedFieldsResetFreqency << std::endl;
         throw eckit::UserError(os.str(), Here());
     }
-    return;
-};
+    return accumulatedFieldsResetFreqency;
+}
 
-void StatisticsOptions::parseValueCountThreshold(const eckit::LocalConfiguration& cfg) {
-    long threshold = cfg.getLong("value-count-threshold", -1);
+std::optional<std::int64_t> parseValueCountThreshold(const eckit::LocalConfiguration& cfg) {
+    const auto threshold = cfg.getLong("value-count-threshold", -1);
 
     if (threshold == -1) {
-        valueCountThreshold_ = std::nullopt;
-        return;
+        return std::nullopt;
     }
     if (threshold > 0) {
-        valueCountThreshold_ = threshold;
-        return;
+        return std::optional{threshold};
     }
 
     std::ostringstream os;
@@ -198,101 +116,94 @@ void StatisticsOptions::parseValueCountThreshold(const eckit::LocalConfiguration
     throw eckit::UserError(os.str(), Here());
 }
 
-void StatisticsOptions::parseDisableStrictMapping(const eckit::LocalConfiguration& cfg) {
-    std::optional<bool> r;
-    r = util::parseBool(cfg, "disable-strict-mapping", false);
+bool parseDisableStrictMapping(const eckit::LocalConfiguration& cfg) {
+    const auto r = util::parseBool(cfg, "disable-strict-mapping", false);
     if (r) {
-        disableStrictMapping_ = *r;
+        return *r;
     }
-    else {
-        usage();
-        throw eckit::SeriousBug{"Unable to read disable-strict-mapping", Here()};
-    }
+    throw eckit::SeriousBug{"Unable to read boolean disable-strict-mapping", Here()};
 }
 
-void StatisticsOptions::parseDisableSquashing(const eckit::LocalConfiguration& cfg) {
-    std::optional<bool> r;
-    r = util::parseBool(cfg, "disable-squashing", false);
+bool parseDisableSquashing(const eckit::LocalConfiguration& cfg) {
+    const auto r = util::parseBool(cfg, "disable-squashing", false);
     if (r) {
-        disableSquashing_ = *r;
+        return *r;
     }
-    else {
-        usage();
-        throw eckit::SeriousBug{"Unable to read disable-squashing", Here()};
-    }
+    throw eckit::SeriousBug{"Unable to read boolean disable-squashing", Here()};
 }
 
-void StatisticsOptions::parseSetMetadata(const eckit::LocalConfiguration& cfg) {
+std::vector<std::pair<std::string, std::string>> parseSetMetadata(const eckit::LocalConfiguration& cfg) {
     if (!cfg.has("set-metadata")) {
-        return;
+        return {};
     }
 
     auto subCfg = cfg.getSubConfiguration("set-metadata");
+    std::vector<std::pair<std::string, std::string>> res;
     for (auto key : subCfg.keys()) {
         auto value = subCfg.getString(key);
-        setMetadata_.emplace_back(std::pair<std::string, std::string>(key, value));
+        res.emplace_back(std::pair<std::string, std::string>(key, value));
     }
+    return res;
 }
 
 
-const std::string& StatisticsOptions::logPrefix() const {
-    return logPrefix_;
-};
+StatisticsOptions::StatisticsOptions(const eckit::LocalConfiguration& cfg) :
+    timeStep_{parseTimeStep(cfg)},
+    solverSendInitStep_{parseInitialConditionPresent(cfg)},  // TODO: rename var
+    readRestart_{parseReadRestart(cfg)},
+    writeRestart_{parseWriteRestart(cfg)},
+    debugRestart_{parseDebugRestart(cfg)},
+    restartTime_{parseRestartTime(cfg)},  // 00000000-000000
+    restartPath_{parseRestartPath(cfg)},
+    restartPrefix_{parseRestartPrefix(cfg)},
+    restartLib_{parseRestartLib(cfg)},
+    logPrefix_{parseRestartPrefix(cfg)},
+    windowType_{parseWindowType(cfg)},
+    accumulatedFieldsResetFreqency_{parseSolverResetAccumulatedFields(cfg)},  // TODO: rename var
+    valueCountThreshold_{parseValueCountThreshold(cfg)},
+    disableStrictMapping_{parseDisableStrictMapping(cfg)},
+    disableSquashing_{parseDisableSquashing(cfg)},
+    setMetadata_{parseSetMetadata(cfg)} {}
 
 
-long StatisticsOptions::timeStep() const {
+std::int64_t StatisticsOptions::timeStep() const {
     return timeStep_;
-};
-
-
+}
 bool StatisticsOptions::solver_send_initial_condition() const {
     return solverSendInitStep_;
-};
+}
 
 bool StatisticsOptions::readRestart() const {
     return readRestart_;
-};
-
-
+}
 bool StatisticsOptions::writeRestart() const {
     return writeRestart_;
-};
-
-
+}
 bool StatisticsOptions::debugRestart() const {
     return debugRestart_;
-};
-
-
+}
 const std::string& StatisticsOptions::restartTime() const {
     return restartTime_;
-};
-
-
+}
 const std::string& StatisticsOptions::restartPath() const {
     return restartPath_;
-};
-
-
+}
 const std::string& StatisticsOptions::restartPrefix() const {
     return restartPrefix_;
-};
-
-
-const std::string& StatisticsOptions::windowType() const {
-    return windowType_;
-};
-
-
+}
 const std::string& StatisticsOptions::restartLib() const {
     return restartLib_;
-};
+}
 
-
+const std::string& StatisticsOptions::logPrefix() const {
+    return logPrefix_;
+}
+const std::string& StatisticsOptions::windowType() const {
+    return windowType_;
+}
 const std::string& StatisticsOptions::solverResetAccumulatedFields() const {
     return accumulatedFieldsResetFreqency_;
-};
-
+}
 
 std::optional<long> StatisticsOptions::valueCountThreshold() const {
     return valueCountThreshold_;
@@ -301,25 +212,11 @@ std::optional<long> StatisticsOptions::valueCountThreshold() const {
 bool StatisticsOptions::disableStrictMapping() const {
     return disableStrictMapping_;
 }
-
 bool StatisticsOptions::disableSquashing() const {
     return disableSquashing_;
 }
-
 const std::vector<std::pair<std::string, std::string>>& StatisticsOptions::setMetadata() const {
     return setMetadata_;
-}
-
-
-void StatisticsOptions::dumpOptions() {
-    // TODO: Implement this function
-    return;
-}
-
-
-void StatisticsOptions::usage() {
-    // TODO: Implement this function
-    return;
 }
 
 }  // namespace multio::action::statistics_mtg2

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include "eckit/config/LocalConfiguration.h"
-#include "multio/action/Action.h"
-#include "multio/config/ComponentConfiguration.h"
-#include "multio/message/Message.h"
 
 
 namespace multio::action::statistics_mtg2 {

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
@@ -17,7 +17,7 @@ namespace multio::action::statistics_mtg2 {
 class StatisticsOptions {
 private:
     const std::int64_t timeStep_;
-    const bool solverSendInitStep_;
+    const bool initialConditionPresent_;
 
     const bool readRestart_;
     const bool writeRestart_;
@@ -29,7 +29,7 @@ private:
 
     const std::string logPrefix_;
     const std::string windowType_;
-    const std::string accumulatedFieldsResetFreqency_;
+    const std::string solverResetAccumulatedFieldsEvery_;
 
     const std::optional<long> valueCountThreshold_;
 
@@ -41,7 +41,7 @@ public:
     StatisticsOptions(const eckit::LocalConfiguration& cfg);
 
     long timeStep() const;
-    bool solver_send_initial_condition() const;  // TODO: rename
+    bool initialConditionPresent() const;
 
     bool readRestart() const;
     bool writeRestart() const;
@@ -53,7 +53,7 @@ public:
 
     const std::string& logPrefix() const;
     const std::string& windowType() const;
-    const std::string& solverResetAccumulatedFields() const;
+    const std::string& solverResetAccumulatedFieldsEvery() const;
 
     std::optional<std::int64_t> valueCountThreshold() const;
 

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "eckit/config/LocalConfiguration.h"
@@ -15,68 +16,46 @@ namespace multio::action::statistics_mtg2 {
  */
 class StatisticsOptions {
 private:
-    // Default values for configurations
-    long timeStep_;
-    bool solverSendInitStep_;
-    bool readRestart_;
-    bool writeRestart_;
-    bool debugRestart_;
-    std::string restartTime_;
+    const std::int64_t timeStep_;
+    const bool solverSendInitStep_;
 
-    std::string restartPath_;
-    std::string restartPrefix_;
-    std::string restartLib_;
-    std::string logPrefix_;
-    std::string windowType_;
-    std::string accumulatedFieldsResetFreqency_;
+    const bool readRestart_;
+    const bool writeRestart_;
+    const bool debugRestart_;
+    const std::string restartTime_;
+    const std::string restartPath_;
+    const std::string restartPrefix_;
+    const std::string restartLib_;
 
-    std::optional<long> valueCountThreshold_;
+    const std::string logPrefix_;
+    const std::string windowType_;
+    const std::string accumulatedFieldsResetFreqency_;
 
-    bool disableStrictMapping_;
-    bool disableSquashing_;
-    std::vector<std::pair<std::string, std::string>> setMetadata_;
+    const std::optional<long> valueCountThreshold_;
 
-private:
-    void parseTimeStep(const eckit::LocalConfiguration& cfg);
-    void parseInitialConditionPresent(const eckit::LocalConfiguration& cfg);
-    void parseWriteRestart(const eckit::LocalConfiguration& cfg);
-    void parseDebugRestart(const eckit::LocalConfiguration& cfg);
-    void parseReadRestart(const eckit::LocalConfiguration& cfg);
-    void parseRestartPath(const eckit::LocalConfiguration& cfg);
-    void parseRestartPrefix(const eckit::LocalConfiguration& cfg);
-    void parseRestartTime(const eckit::LocalConfiguration& cfg);
-    void parseRestartLib(const eckit::LocalConfiguration& cfg);
-    void parseLogPrefix(const eckit::LocalConfiguration& cfg);
-    void parseWindowType(const eckit::LocalConfiguration& cfg);
-    void parseSolverResetAccumulatedFields(const eckit::LocalConfiguration& cfg);
-    void parseValueCountThreshold(const eckit::LocalConfiguration& cfg);
-    void parseDisableStrictMapping(const eckit::LocalConfiguration& cfg);
-    void parseDisableSquashing(const eckit::LocalConfiguration& cfg);
-    void parseSetMetadata(const eckit::LocalConfiguration& cfg);
-
-    void dumpOptions();
-    void usage();
+    const bool disableStrictMapping_;
+    const bool disableSquashing_;
+    const std::vector<std::pair<std::string, std::string>> setMetadata_;
 
 public:
-    StatisticsOptions(const config::ComponentConfiguration& compConf);
+    StatisticsOptions(const eckit::LocalConfiguration& cfg);
 
-    const std::string& logPrefix() const;
-    const std::string& windowType() const;
-
-    // Default values
     long timeStep() const;
-    bool solver_send_initial_condition() const;
+    bool solver_send_initial_condition() const;  // TODO: rename
+
     bool readRestart() const;
     bool writeRestart() const;
     bool debugRestart() const;
-
     const std::string& restartTime() const;
     const std::string& restartPath() const;
     const std::string& restartPrefix() const;
     const std::string& restartLib() const;
+
+    const std::string& logPrefix() const;
+    const std::string& windowType() const;
     const std::string& solverResetAccumulatedFields() const;
 
-    std::optional<long> valueCountThreshold() const;
+    std::optional<std::int64_t> valueCountThreshold() const;
 
     bool disableStrictMapping() const;
     bool disableSquashing() const;

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
@@ -29,7 +29,7 @@ private:
     const std::string windowType_;
     const std::string solverResetAccumulatedFieldsEvery_;
 
-    const std::optional<long> valueCountThreshold_;
+    const std::optional<std::int64_t> valueCountThreshold_;
 
     const bool disableStrictMapping_;
     const bool disableSquashing_;
@@ -38,7 +38,7 @@ private:
 public:
     StatisticsOptions(const eckit::LocalConfiguration& cfg);
 
-    long timeStep() const;
+    std::int64_t timeStep() const;
     bool initialConditionPresent() const;
 
     bool readRestart() const;

--- a/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
+++ b/src/multio/action/statistics-mtg2/cfg/StatisticsOptions.h
@@ -42,18 +42,17 @@ private:
     void parseWriteRestart(const eckit::LocalConfiguration& cfg);
     void parseDebugRestart(const eckit::LocalConfiguration& cfg);
     void parseReadRestart(const eckit::LocalConfiguration& cfg);
-    void parseRestartPath(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
-    void parseRestartPrefix(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
-    void parseRestartTime(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
+    void parseRestartPath(const eckit::LocalConfiguration& cfg);
+    void parseRestartPrefix(const eckit::LocalConfiguration& cfg);
+    void parseRestartTime(const eckit::LocalConfiguration& cfg);
     void parseRestartLib(const eckit::LocalConfiguration& cfg);
-    void parseLogPrefix(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
-    void parseWindowType(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
-    void parseSolverResetAccumulatedFields(const config::ComponentConfiguration& compConf,
-                                           const eckit::LocalConfiguration& cfg);
-    void parseValueCountThreshold(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
-    void parseDisableStrictMapping(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
+    void parseLogPrefix(const eckit::LocalConfiguration& cfg);
+    void parseWindowType(const eckit::LocalConfiguration& cfg);
+    void parseSolverResetAccumulatedFields(const eckit::LocalConfiguration& cfg);
+    void parseValueCountThreshold(const eckit::LocalConfiguration& cfg);
+    void parseDisableStrictMapping(const eckit::LocalConfiguration& cfg);
     void parseDisableSquashing(const eckit::LocalConfiguration& cfg);
-    void parseSetMetadata(const config::ComponentConfiguration& compConf, const eckit::LocalConfiguration& cfg);
+    void parseSetMetadata(const eckit::LocalConfiguration& cfg);
 
     void dumpOptions();
     void usage();

--- a/src/multio/action/statistics-mtg2/operations/OperationWithDeaccumulatedData.h
+++ b/src/multio/action/statistics-mtg2/operations/OperationWithDeaccumulatedData.h
@@ -179,25 +179,24 @@ private:
     const std::string restartFileName() const { return name_ + "_" + (sizeof(T) == 4 ? "single" : "double"); };
 
     bool solverResetAccumulatedFields(const message::Message& msg, const StatisticsConfiguration& cfg) {
-
-        if (cfg.options().solverResetAccumulatedFields() == "hour") {
+        if (cfg.options().solverResetAccumulatedFieldsEvery() == "hour") {
             return isBeginningOfHour(msg, cfg);
         }
-        if (cfg.options().solverResetAccumulatedFields() == "day") {
+        if (cfg.options().solverResetAccumulatedFieldsEvery() == "day") {
             return isBeginningOfDay(msg, cfg);
         }
-        if (cfg.options().solverResetAccumulatedFields() == "month") {
+        if (cfg.options().solverResetAccumulatedFieldsEvery() == "month") {
             return isBeginningOfMonth(msg, cfg);
         }
-        if (cfg.options().solverResetAccumulatedFields() == "year") {
+        if (cfg.options().solverResetAccumulatedFieldsEvery() == "year") {
             return isBeginningOfYear(msg, cfg);
         }
-        if (cfg.options().solverResetAccumulatedFields() == "never") {
+        if (cfg.options().solverResetAccumulatedFieldsEvery() == "never") {
             return false;
         }
 
         std::ostringstream os;
-        os << "Invalid reset period of accumulated fields :: " << cfg.options().solverResetAccumulatedFields()
+        os << "Invalid reset period of accumulated fields :: " << cfg.options().solverResetAccumulatedFieldsEvery()
            << std::endl;
         throw eckit::UserError(os.str(), Here());
     }

--- a/src/multio/action/statistics-mtg2/synoptic-filters/DailyCustomFilter.h
+++ b/src/multio/action/statistics-mtg2/synoptic-filters/DailyCustomFilter.h
@@ -19,9 +19,9 @@ namespace {
 std::vector<long> initDailyCustomFilterReadArray(const eckit::LocalConfiguration& compConf,
                                                  const StatisticsConfiguration& cfg) {
     std::vector<long> tmp;
-    LOG_DEBUG_LIB(LibMultio) << cfg.logPrefix() << " + Initialize new DailyCustomFilter with explicit configuration"
+    LOG_DEBUG_LIB(LibMultio) << cfg.options().logPrefix() << " + Initialize new DailyCustomFilter with explicit configuration"
                              << std::endl;
-    LOG_DEBUG_LIB(LibMultio) << cfg.logPrefix() << " + Config    :: " << compConf << std::endl;
+    LOG_DEBUG_LIB(LibMultio) << cfg.options().logPrefix() << " + Config    :: " << compConf << std::endl;
     tmp = compConf.getLongVector("hours-set");
     std::sort(tmp.begin(), tmp.end());
     long old = -1;
@@ -34,7 +34,7 @@ std::vector<long> initDailyCustomFilterReadArray(const eckit::LocalConfiguration
         }
         old = i;
     }
-    LOG_DEBUG_LIB(LibMultio) << cfg.logPrefix() << " + Hours set :: " << tmp << std::endl;
+    LOG_DEBUG_LIB(LibMultio) << cfg.options().logPrefix() << " + Hours set :: " << tmp << std::endl;
     return tmp;
 };
 
@@ -42,18 +42,18 @@ std::vector<long> initDailyCustomFilterReadArray(const eckit::LocalConfiguration
 std::vector<long> initDailyCustomFilterReadVars(const eckit::LocalConfiguration& compConf,
                                                 const StatisticsConfiguration& cfg) {
     std::vector<long> tmp;
-    LOG_DEBUG_LIB(LibMultio) << cfg.logPrefix() << " + Initialize new DailyCustomFilter with from/to/by configuration"
+    LOG_DEBUG_LIB(LibMultio) << cfg.options().logPrefix() << " + Initialize new DailyCustomFilter with from/to/by configuration"
                              << std::endl;
-    LOG_DEBUG_LIB(LibMultio) << cfg.logPrefix() << " + Config    :: " << compConf << std::endl;
+    LOG_DEBUG_LIB(LibMultio) << cfg.options().logPrefix() << " + Config    :: " << compConf << std::endl;
     long from;
     long to;
     long by;
     from = compConf.getLong("from");
     to = compConf.getLong("to");
     by = compConf.getLong("by", 1);
-    LOG_DEBUG_LIB(LibMultio) << cfg.logPrefix() << " + From    :: " << from << std::endl;
-    LOG_DEBUG_LIB(LibMultio) << cfg.logPrefix() << " + To      :: " << to << std::endl;
-    LOG_DEBUG_LIB(LibMultio) << cfg.logPrefix() << " + By      :: " << by << std::endl;
+    LOG_DEBUG_LIB(LibMultio) << cfg.options().logPrefix() << " + From    :: " << from << std::endl;
+    LOG_DEBUG_LIB(LibMultio) << cfg.options().logPrefix() << " + To      :: " << to << std::endl;
+    LOG_DEBUG_LIB(LibMultio) << cfg.options().logPrefix() << " + By      :: " << by << std::endl;
     if (by < 1 || by > 23) {
         throw eckit::SeriousBug{"\"by\" out of range", Here()};
     }
@@ -66,7 +66,7 @@ std::vector<long> initDailyCustomFilterReadVars(const eckit::LocalConfiguration&
     for (long i = from; i <= to; i = i + by) {
         tmp.push_back(i);
     }
-    LOG_DEBUG_LIB(LibMultio) << cfg.logPrefix() << " + Hours set :: " << tmp << std::endl;
+    LOG_DEBUG_LIB(LibMultio) << cfg.options().logPrefix() << " + Hours set :: " << tmp << std::endl;
     return tmp;
 };
 


### PR DESCRIPTION
- get rid of some unused methods
- make all variables const
- simplify the "time utils", and get rid of the unused/duplicate methods
- rename some methods/variables to follow the usual convention

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-168
<!-- PREVIEW-URL_END -->