### PR TITLE
Fix mars2mars test failure because bitsPerValue is not set

### DIFF
--- a/tests/multio/mars2mars/test_multio_mars2mars_mappings.cc
+++ b/tests/multio/mars2mars/test_multio_mars2mars_mappings.cc
@@ -456,8 +456,7 @@ CASE("Test heightAboveSea") {
 
         EXPECT(res);
         EXPECT(mars.levelist.get() == 10);
-        EXPECT(misc.bitsPerValue.isSet());
-        EXPECT(misc.bitsPerValue.get() == 24);
+        EXPECT(!misc.bitsPerValue.isSet());
     }
 };
 


### PR DESCRIPTION
### Description

A previous merge has caused a failing test in `mars2mars` mapping. BitsPerValue is not set anymore for params 140233, 140245, 140249.
The test was not adjusted.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-172
<!-- PREVIEW-URL_END -->