### PR TITLE
Fixes for 2.7.3 to successfully compile with CCE19.0.0 and Ninja

### DIFF
--- a/src/multio/datamod/ContainerInterop.h
+++ b/src/multio/datamod/ContainerInterop.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <type_traits>
 #include "eckit/config/LocalConfiguration.h"
 #include "metkit/codes/CodesDecoder.h"

--- a/src/multio/datamod/types/TypeOfLevel.cc
+++ b/src/multio/datamod/types/TypeOfLevel.cc
@@ -8,6 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
+#include <algorithm>
 #include "TypeOfLevel.h"
 #include "multio/datamod/core/DataModellingException.h"
 
@@ -335,4 +336,3 @@ void util::Print<datamod::TypeOfLevel>::print(PrintStream& ps, const datamod::Ty
 }
 
 }  // namespace multio
-

--- a/src/multio/mars2grib/sections/SectionTypes.cc
+++ b/src/multio/mars2grib/sections/SectionTypes.cc
@@ -8,6 +8,7 @@
  * does it submit to any jurisdiction.
  */
 
+#include <algorithm>
 #include "multio/mars2grib/sections/SectionTypes.h"
 #include "multio/mars2grib/Mars2GribException.h"
 
@@ -55,4 +56,3 @@ std::ostream& operator<<(std::ostream& os, const TimeRangeType& t) {
     return os;
 }
 }  // namespace multio::mars2grib::sections
-

--- a/src/multiom/api/api_encode_c.cc
+++ b/src/multiom/api/api_encode_c.cc
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <algorithm>
 #include <functional>
 #include <iomanip>
 #include <iostream>

--- a/src/multiom/encoders-base/CMakeLists.txt
+++ b/src/multiom/encoders-base/CMakeLists.txt
@@ -20,7 +20,6 @@ set( MULTIOM_ENCODERS_BASE_MAIN_SOURCES
 # Collect source files in module2
 set( MULTIOM_ENCODERS_BASE_SOURCES
   ${MULTIOM_ENCODERS_BASE_MAIN_SOURCES}
-  ${MULTIOM_ENCODER_GRIB2_SOURCES}
   CACHE INTERNAL "List of all sources in operations directory"
 )
 


### PR DESCRIPTION
### Description

grib2 encoder files were compiled twice, for multiom-encoder and multiom-core. That is unnecessary and causes a race condition on the module files since both targets write to the same module directory. Ninja refuses to built because of this.
db1da60cdc08cfeeedcd963dba8c1836f3347f3e removes the grib2 files from the core target.

In addition, several files use utilities from the STL's algorithm library without specifying the appropriate include. 1b054527a8446304b9ba5d2dd141607edf94f470 fixes this.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 