### PR TITLE
Remove step-meter tests that test unsupported behavior

### DIFF
--- a/tests/multio/CMakeLists.txt
+++ b/tests/multio/CMakeLists.txt
@@ -360,17 +360,9 @@ ecbuild_add_test( TARGET          test_multio_step_meter_synced
                                   TIMEOUT       10
 )
 
-ecbuild_add_test( TARGET          test_multio_step_meter_asymmetric
-                  COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/test_multio_step_meter.sh
-                  ARGS            2 12 0,1,2,3,4,5,6,7,8,9,10,11,12 0,3,6,9,12
-                  ENVIRONMENT     "${_step_meter_environment}"
-                  TEST_PROPERTIES RESOURCE_LOCK mpi
-                                  TIMEOUT       10
-)
-
 ecbuild_add_test( TARGET          test_multio_step_meter_stalled
                   COMMAND         ${CMAKE_CURRENT_SOURCE_DIR}/test_multio_step_meter.sh
-                  ARGS            2 8 0,4,8 0,3,6,9,12
+                  ARGS            2 8 0,1,2,3,4,5,6,7,8 0,1,2,3,4,5,6,7,8,9,10,11,12
                   ENVIRONMENT     "${_step_meter_environment}"
                   TEST_PROPERTIES RESOURCE_LOCK mpi
                                   TIMEOUT       10


### PR DESCRIPTION
We do not support updating the step meter at different rates from different clients. The tests for this behavior is removed in this PR. The "stalled" test is updated to have the update rate in sync.

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-274
<!-- PREVIEW-URL_END -->