### PR TITLE
Fix passing through misc keys in encode-mtg2

### DIFF
--- a/src/multio/action/encode-mtg2/EncodeMtg2.cc
+++ b/src/multio/action/encode-mtg2/EncodeMtg2.cc
@@ -46,7 +46,7 @@ std::unique_ptr<metkit::codes::CodesHandle> encode(metkit::mars2grib::Mars2Grib&
                                                    T* values, size_t size, const dm::FullMarsRecord& marsRec,
                                                    const dm::MiscRecord& miscRec) {
     const auto mars = dm::dumpRecord<eckit::LocalConfiguration>(marsRec);
-    const auto misc = dm::dumpRecord<eckit::LocalConfiguration>(miscRec);
+    const auto misc = dm::dumpUnscopedRecord<eckit::LocalConfiguration>(miscRec);
 
     if (!cache) {
         return encoder.encode(values, size, mars, misc);
@@ -88,10 +88,6 @@ void EncodeMtg2::executeImpl(Message msg) {
     // Apply mappings
     auto mappingResult = mars2mars::applyMappings(mars2mars::allRules(), marsRec, miscRec);
 
-    // Dump (mapped) mars and misc keys to local configurations
-    const auto mars = dm::dumpRecord<eckit::LocalConfiguration>(marsRec);
-    const auto misc = dm::dumpUnscopedRecord<eckit::LocalConfiguration>(miscRec);
-
     executeNext(dispatchPrecisionTag(msg.precision(), [&](auto pt) {
         using Precision = typename decltype(pt)::type;
         msg.payload().acquire();
@@ -123,7 +119,6 @@ void EncodeMtg2::executeImpl(Message msg) {
         eckit::Buffer buf{sample->messageSize()};
         sample->copyInto(reinterpret_cast<uint8_t*>(buf.data()), buf.size());
 
-        // TODO(pgeier) write mapped metadata
         return Message{Message::Header{Message::Tag::Field, Peer{msg.source()}, Peer{msg.destination()},
                                        dm::dumpRecord<message::Metadata>(marsRec)},
                        std::move(buf)};


### PR DESCRIPTION
### Description
All keys with "misc-" prefix never made it properly to the mars2grib.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-275
<!-- PREVIEW-URL_END -->