### PR TITLE
Mark metkit MARS2GRIB as a required feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,10 @@ if( NOT metkit_HAVE_GRIB )
   ecbuild_critical( "metkit must be built with GRIB support" )
 endif()
 
+if( NOT metkit_HAVE_MARS2GRIB )
+  ecbuild_critical( "metkit must be build with feature MARS2GRIB" )
+endif()
+
 ### fdb5 plugin
 
 ecbuild_add_option( FEATURE FDB5


### PR DESCRIPTION
This change will let the build error out in the configuration stage if metkit was not build with feature `MARS2GRIB`, which is needed in the `encode-mtg2` action and `grib1-to-grib2` tool.

<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-276
<!-- PREVIEW-URL_END -->