### PR TITLE
grib1-to-grib2: fix satellite products extraction:

### DIFF
--- a/src/multio/tools/utils/distGrib1ToGrib2ProcessFiles.cc
+++ b/src/multio/tools/utils/distGrib1ToGrib2ProcessFiles.cc
@@ -152,6 +152,7 @@ FileOutcome processOneFile(int rank, const std::string& file, const grib2MarsMis
                 case MessageDisposition::SkipInvalidMessage:
                 case MessageDisposition::SkipDiscipline192:
                 case MessageDisposition::SkipTimespanNonPositive:
+                case MessageDisposition::ComplexExclusion:
                     bumpOutcome(outcome, extractionOutcome.code);
                     break;
                 case MessageDisposition::FailToExtract:

--- a/src/multio/tools/utils/grib2MarsMisc.cc
+++ b/src/multio/tools/utils/grib2MarsMisc.cc
@@ -465,7 +465,7 @@ namespace extract {
 
 void handlePackingType(metkit::codes::CodesHandle& h, const std::string& packingType, dm::FullMarsRecord& mars) {
     const static std::unordered_map<std::string, std::string> packingMap{
-        {"grid_simple", "simple"}, {"grid_complex", "complex"}, {"spectral_complex", "complex"},
+        {"grid_simple", "ccsds"}, {"grid_complex", "complex"}, {"spectral_complex", "complex"},
         {"grid_ccsds", "ccsds"},   {"grid_ieee", "ccsds"},      {"grid_second_order", "ccsds"}};
 
     const auto packingTypeVal = packingMap.find(packingType);
@@ -911,6 +911,12 @@ MessageDisposition classifyTimespanNonPositive(const TimeSpanEqualToZeroHandling
     return MessageDisposition::FailToExtract;
 }
 
+MessageDisposition classifyComplexExclusion() {
+        return MessageDisposition::ComplexExclusion;
+}
+
+
+
 ExtractionOutcome makeOutcome(MessageDisposition disposition, ExtractionOutcomeCode code, std::string reason,
                               std::string detail = {}) {
     return ExtractionOutcome{disposition, code, std::move(reason), std::move(detail)};
@@ -1220,6 +1226,18 @@ Grib2MarsMiscResult grib2MarsMisc(const eckit::message::Message& msg, const Grib
                                 : ExtractionOutcomeCode::SkipRequiredTimespanNonPositive;
             return makeResult(makeOutcome(disposition, code, "timespan-nonpositive",
                                           std::string{"timespan="} + std::to_string(marsConfig.getLong("timespan"))));
+        }
+
+
+        if (marsConfig.has("param") && marsConfig.has("levtype") && marsConfig.has("levelist") ) {
+            if ( marsConfig.getLong("param") == 152 && marsConfig.getString("levtype") == "ml" && marsConfig.getLong("levelist") == 100000 ) {
+                const auto disposition = classifyComplexExclusion();
+                const auto code = (disposition == MessageDisposition::ComplexExclusion)
+                                    ? ExtractionOutcomeCode::ExtractFailedComplexExclusion
+                                    : ExtractionOutcomeCode::ExtractFailedUnknownException;
+                return makeResult(makeOutcome(disposition, code, "complex-exclusion",
+                                              std::string{"param="} + std::to_string(marsConfig.getLong("param"))));
+            }
         }
 
         return makeResult(

--- a/src/multio/tools/utils/grib2MarsMisc.h
+++ b/src/multio/tools/utils/grib2MarsMisc.h
@@ -94,6 +94,7 @@ enum class MessageDisposition
     FailToExtract,
     FailToEncode,
     FailToArchive,
+    ComplexExclusion,
 };
 
 enum class ExtractionOutcomeCode : std::uint8_t
@@ -126,6 +127,7 @@ enum class ExtractionOutcomeCode : std::uint8_t
     EncodeFailedMars2Grib,
     ArchiveFailedSinkWrite,
     ExtractFailedUnknownException,
+    ExtractFailedComplexExclusion,
 };
 
 struct ExtractionOutcome {


### PR DESCRIPTION
- packing type needs to be ccsds for all fields that originally are grid_simple
- param=152,levtype=ml,levelist=100000 needs to be skipped

### Description
We need to wait to merge until its checked by DGOV

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-287
<!-- PREVIEW-URL_END -->