### PR TITLE
[python] remove fortran

### DIFF
--- a/python/multiolib/buildconfig
+++ b/python/multiolib/buildconfig
@@ -11,9 +11,9 @@
 # TODO we duplicate information -- pyproject.toml's `name` and `packages` are derivable from $NAME and must stay consistent
 
 NAME="multio"
-CMAKE_PARAMS1="-Deckit_ROOT=/tmp/multio/prereqs/eckitlib -Deccodes_ROOT=/tmp/multio/prereqs/eccodeslib -Dmetkit_ROOT=/tmp/multio/prereqs/metkitlib -Datlas_ROOT=/tmp/multio/prereqs/atlaslib-ecmwf -Dfdb5_ROOT=/tmp/multio/prereqs/fdb5lib -Dmir_ROOT=/tmp/multio/prereqs/mirlib -Dfckit_ROOT=/tmp/multio/prereqs/fckitlib"
-CMAKE_PARAMS2="-DENABLE_ATLAS_IO=1"
+CMAKE_PARAMS1="-Deckit_ROOT=/tmp/multio/prereqs/eckitlib -Deccodes_ROOT=/tmp/multio/prereqs/eccodeslib -Dmetkit_ROOT=/tmp/multio/prereqs/metkitlib -Datlas_ROOT=/tmp/multio/prereqs/atlaslib-ecmwf -Dfdb5_ROOT=/tmp/multio/prereqs/fdb5lib -Dmir_ROOT=/tmp/multio/prereqs/mirlib"
+CMAKE_PARAMS2="-DENABLE_ATLAS_IO=1 -DENABLE_FORTRAN=0 -DENABLE_MULTIO_OUTPUT_MANAGER=OFF"
 CMAKE_PARAMS="$CMAKE_PARAMS1 $CMAKE_PARAMS2"
 PYPROJECT_DIR="python/multiolib"
-DEPENDENCIES='["eckitlib", "eccodeslib", "metkitlib", "atlaslib-ecmwf", "fdb5lib", "mirlib", "fckitlib"]'
+DEPENDENCIES='["eckitlib", "eccodeslib", "metkitlib", "atlaslib-ecmwf", "fdb5lib", "mirlib"]'
 export VERSION_MICROINCR="no"


### PR DESCRIPTION
disable fortran

disable mulio manage

remove fckit as a dependency

none of that is needed in the wheels anymore

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 


<!-- PREVIEW-URL_BEGIN -->
🌈🌦️📖🚧 Documentation 🚧📖🌦️🌈
https://sites.ecmwf.int/docs/dev-section/multio/pull-requests/PR-288
<!-- PREVIEW-URL_END -->