### PR TITLE
DE-3673 Fix levtype for time statistics on snow depth (228141)

### DIFF
--- a/src/multio/mars2mars/Rules.cc
+++ b/src/multio/mars2mars/Rules.cc
@@ -169,8 +169,17 @@ auto fixMapToSol() {
     return rule(
         all(OneOf{&dm::FullMarsRecord::levtype, {dm::LevType::SFC}}, Has{&dm::FullMarsRecord::levelist},
             NoneOf{&dm::FullMarsRecord::levelist, {0}},
-            matchParams(33, 238, 228038, 228141, 235078, 237078, 238078, 239078, 235080, 237080, 238080, 239080, 235238, 237238, 238238, 239238, 235406, 237406, 238406, 239406, 260360, 262000, 262024, 260199)),  //
+            matchParams(33, 238, 228038, 228141, 235080, 237080, 238080, 239080, 260360, 262000, 262024, 260199)),  //
         setKey(&dm::FullMarsRecord::levtype, dm::LevType::SOL));                                             //
+}
+
+auto fixSnowMapToSol() {
+    return rule(
+        all(OneOf{&dm::FullMarsRecord::levtype, {dm::LevType::SFC}}, Has{&dm::FullMarsRecord::levelist},
+            NoneOf{&dm::FullMarsRecord::levelist, {0}},
+            matchParams(235078, 237078, 238078, 239078, 235238, 237238, 238238, 239238,
+                        235406, 237406, 238406, 239406)),  //
+        setKey(&dm::FullMarsRecord::levtype, dm::LevType::SOL));
 }
 
 
@@ -662,6 +671,7 @@ const RuleList& fixIFSOutput() {
         fixHeightAboveGround10m(),      //
         fixHeightAboveSea(),            //
         fixMapToSol(),                  //
+        fixSnowMapToSol(),              //
         fixWindspeedU100m(),            //
         fixWindspeedU200m(),            //
         fixWindspeedV100m(),            //

--- a/src/multio/mars2mars/Rules.cc
+++ b/src/multio/mars2mars/Rules.cc
@@ -169,7 +169,7 @@ auto fixMapToSol() {
     return rule(
         all(OneOf{&dm::FullMarsRecord::levtype, {dm::LevType::SFC}}, Has{&dm::FullMarsRecord::levelist},
             NoneOf{&dm::FullMarsRecord::levelist, {0}},
-            matchParams(33, 238, 228038, 228141, 235078, 237078, 238078, 239078, 235080, 237080, 238080, 239080, 260360, 262000, 262024, 260199)),  //
+            matchParams(33, 238, 228038, 228141, 235078, 237078, 238078, 239078, 235080, 237080, 238080, 239080, 235406, 237406, 238406, 239406, 260360, 262000, 262024, 260199)),  //
         setKey(&dm::FullMarsRecord::levtype, dm::LevType::SOL));                                             //
 }
 

--- a/src/multio/mars2mars/Rules.cc
+++ b/src/multio/mars2mars/Rules.cc
@@ -169,7 +169,7 @@ auto fixMapToSol() {
     return rule(
         all(OneOf{&dm::FullMarsRecord::levtype, {dm::LevType::SFC}}, Has{&dm::FullMarsRecord::levelist},
             NoneOf{&dm::FullMarsRecord::levelist, {0}},
-            matchParams(33, 238, 228038, 228141, 235080, 237080, 238080, 239080, 260360, 262000, 262024, 260199)),  //
+            matchParams(33, 238, 228038, 228141, 235078, 237078, 238078, 239078, 235080, 237080, 238080, 239080, 260360, 262000, 262024, 260199)),  //
         setKey(&dm::FullMarsRecord::levtype, dm::LevType::SOL));                                             //
 }
 

--- a/src/multio/mars2mars/Rules.cc
+++ b/src/multio/mars2mars/Rules.cc
@@ -169,7 +169,7 @@ auto fixMapToSol() {
     return rule(
         all(OneOf{&dm::FullMarsRecord::levtype, {dm::LevType::SFC}}, Has{&dm::FullMarsRecord::levelist},
             NoneOf{&dm::FullMarsRecord::levelist, {0}},
-            matchParams(33, 238, 228038, 228141, 235078, 237078, 238078, 239078, 235080, 237080, 238080, 239080, 235406, 237406, 238406, 239406, 260360, 262000, 262024, 260199)),  //
+            matchParams(33, 238, 228038, 228141, 235078, 237078, 238078, 239078, 235080, 237080, 238080, 239080, 235238, 237238, 238238, 239238, 235406, 237406, 238406, 239406, 260360, 262000, 262024, 260199)),  //
         setKey(&dm::FullMarsRecord::levtype, dm::LevType::SOL));                                             //
 }
 

--- a/tests/multio/mars2mars/test_multio_mars2mars_mappings.cc
+++ b/tests/multio/mars2mars/test_multio_mars2mars_mappings.cc
@@ -466,7 +466,9 @@ CASE("Test mapToSol") {
     using namespace multio::mars2mars;
     using namespace multio::datamod;
 
-    std::vector<std::int64_t> paramIds{{33, 238, 228038, 235238, 237238, 238238, 239238, 235406, 237406, 238406, 239406, 260360, 262000, 262024, 260199}};
+    std::vector<std::int64_t> paramIds{{33, 238, 228038, 228141, 235078, 237078, 238078, 239078, 235080, 237080,
+                                        238080, 239080, 235238, 237238, 238238, 239238, 235406, 237406, 238406,
+                                        239406, 260360, 262000, 262024, 260199}};
 
     for (auto paramId : paramIds) {
         FullMarsRecord mars;

--- a/tests/multio/mars2mars/test_multio_mars2mars_mappings.cc
+++ b/tests/multio/mars2mars/test_multio_mars2mars_mappings.cc
@@ -466,7 +466,7 @@ CASE("Test mapToSol") {
     using namespace multio::mars2mars;
     using namespace multio::datamod;
 
-    std::vector<std::int64_t> paramIds{{33, 238, 228038, 260360, 262000, 262024, 260199}};
+    std::vector<std::int64_t> paramIds{{33, 238, 228038, 235406, 237406, 238406, 239406, 260360, 262000, 262024, 260199}};
 
     for (auto paramId : paramIds) {
         FullMarsRecord mars;
@@ -481,6 +481,18 @@ CASE("Test mapToSol") {
         EXPECT(res);
         EXPECT(mars.levtype.get() == LevType::SOL);
     }
+
+    FullMarsRecord levelZeroMars;
+    MiscRecord levelZeroMisc;
+
+    levelZeroMars.param.set(235406);
+    levelZeroMars.levtype.set(LevType::SFC);
+    levelZeroMars.levelist.set(0);
+
+    auto levelZeroResult = mars2mars::applyMappings(mars2mars::allRules(), levelZeroMars, levelZeroMisc);
+
+    EXPECT(!levelZeroResult);
+    EXPECT(levelZeroMars.levtype.get() == LevType::SFC);
 };
 
 

--- a/tests/multio/mars2mars/test_multio_mars2mars_mappings.cc
+++ b/tests/multio/mars2mars/test_multio_mars2mars_mappings.cc
@@ -466,7 +466,7 @@ CASE("Test mapToSol") {
     using namespace multio::mars2mars;
     using namespace multio::datamod;
 
-    std::vector<std::int64_t> paramIds{{33, 238, 228038, 235406, 237406, 238406, 239406, 260360, 262000, 262024, 260199}};
+    std::vector<std::int64_t> paramIds{{33, 238, 228038, 235238, 237238, 238238, 239238, 235406, 237406, 238406, 239406, 260360, 262000, 262024, 260199}};
 
     for (auto paramId : paramIds) {
         FullMarsRecord mars;


### PR DESCRIPTION
The climate DT portfolio required for CY49R3 includes snow depth water equivalent, both instantaneous (228141) and time-averaged (235078). These parameters should be encoded as both levtype=sfc (vertical sum) and levtype=sol (per-level, five layers for snow variables). The branch used by 49r3 climate DT has a sfc->sol mapping for paramid 228141 (instantaneous), but not for 235078 (its time-averaged version).

JIRA: https://jira.ecmwf.int/browse/DE-3673

### Description

The sfc->sol levtype fix in fixMapToSol() covered the instantaneous snow
    depth (228141) but not its statistically processed variants produced by
    statistics-mtg2 (average->235078, max->237078, min->238078, stddev->239078).
    As a result the monthly-averaged snow depth kept the wrong levtype and did
    not encode/archive. Add the four time-processed params to the rule.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
